### PR TITLE
fixup yamllint warnings/errors

### DIFF
--- a/custom_components/icloud3/sample-automations-scripts/au_garage_door.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/au_garage_door.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   AUTOMATIONS_OLD
@@ -8,48 +10,48 @@
 #########################################################
 
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   If the Garage Door is open after 8pm, close it
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Close Garage Door (Open after 8pm)
   id: close_garage_door_after_8pm
   trigger:
     platform: time
     at: '20:00:00'
-    
+
   condition:
     condition: state
     entity_id: sensor.garage_door
     state: 'Open'
-    
+
   action:
     - service: switch.turn_on
       entity_id: switch.garage_door
-      
+
     - service: script.notify_gary_iphone
       data:
         title: Garage Door Closed
         message: After 8pm - Close Door Automation Triggered
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   If the Garage Door is open and no one is home, close it
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Close Garage Door (No One Home)
   id: close_garage_door_no_one_home
   trigger:
     platform: state
     entity_id: sensor.someone_home_flag
     to: 'all away'
-    
+
   condition:
     condition: state
     entity_id: sensor.garage_door
     state: 'Open'
-    
+
   action:
     - service: switch.turn_on
       entity_id: switch.garage_door
-      
+
     - service: script.notify_gary_iphone
       data:
         title: Garage Door Closed

--- a/custom_components/icloud3/sample-automations-scripts/au_home_away_gary.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/au_home_away_gary.yaml
@@ -1,11 +1,14 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:line-length
+
 ################################################################
 #
 #   AUTOMATIONS_OLD - Gary Zone Automations
 #
 ################################################################
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Gary arrives home
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Arrives Home
   id: gary_arrives_home
   trigger:
@@ -15,84 +18,84 @@
 
     - platform: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float <= 0.2}}'
-      
-  condition: 
+
+  condition:
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'on'
-      
+
   action:
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Arrives Home'
-        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}' 
-            
+        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}'
+
     - service: script.gary_arrives_home
-    
-#--------------------------------------------------------------
+
+# -------------------------------------------------------------
 #   Gary leaves home zone
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Leaves Home
   id: gary_leaves_home
   trigger:
     - platform: state
       entity_id: sensor.gary_iphone_zone_name1
       to: 'Away'
-      
-  condition: 
+
+  condition:
     - condition: template
       value_template: '{{trigger.from_state.state == "Home"}}'
-      
+
     - condition: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 0}}'
-    
+
     - condition: state
       entity_id: input_boolean.ha_started_flag
-      state: 'on'    
+      state: 'on'
   action:
     - service: script.gary_leaves_home
- 
+
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Leaves Home'
-        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}' 
-        
+        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}'
+
     - service: script.gary_leaves_zone
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Gary leaves a zone
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Leaves Zone
   id: gary_leaves_zone
   trigger:
     - platform: state
       entity_id: sensor.gary_iphone_zone_name1
       to: 'Away'
-      
-  condition: 
+
+  condition:
     - condition: template
       value_template: '{{trigger.from_state.state != "Home"}}'
-      
+
     - condition: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 0}}'
-    
+
     - condition: state
       entity_id: input_boolean.ha_started_flag
-      state: 'on'    
+      state: 'on'
   action:
     - service: script.gary_leaves_zone
-        
+
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Leaves Zone'
-        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}' 
+        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}'
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Turn on Gary's Driving Flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Driving Flag Turn On
   id: gary_driving_flag_turn_on
-        
+
   trigger:
     - platform: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 2}}'
@@ -101,14 +104,14 @@
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'off'
-       
+
   action:
     - service: input_boolean.turn_on
       entity_id: input_boolean.gary_driving_flag
-         
-#--------------------------------------------------------------
+
+# -------------------------------------------------------------
 #   Turn off Gary's Driving Flag if Home for 15 minutes if still on
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Driving Flag Turn Off
   id: gary_driving_flag_turn_off
   trigger:
@@ -117,39 +120,39 @@
       to: 'home'
       for:
         minutes: 15
-    
+
   condition:
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'on'
-      
+
   action:
     - service: input_boolean.turn_off
       entity_id: input_boolean.gary_driving_flag
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Turn on Gary's Far Away Flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Far Away Flag Turn On
   id: gary_far_away_flag_turn_on
   trigger:
     - platform: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 5}}'
-      
+
   condition:
     - condition: state
       entity_id: input_boolean.gary_far_away_flag
       state: 'off'
-      
+
   action:
     - service: input_boolean.turn_on
       entity_id: input_boolean.gary_driving_flag
 
     - service: input_boolean.turn_on
       entity_id: input_boolean.gary_far_away_flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Turn off Gary's Far Away Flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Far Away Flag Turn Off
   id: gary_far_away_flag_turn_off
   trigger:
@@ -160,8 +163,7 @@
     - condition: state
       entity_id: input_boolean.gary_far_away_flag
       state: 'on'
-      
+
   action:
     service: input_boolean.turn_off
     entity_id: input_boolean.gary_far_away_flag
-

--- a/custom_components/icloud3/sample-automations-scripts/au_icloud.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/au_icloud.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   IPHONE/ICLOUD SELECTION AUTOMATIONS
@@ -24,7 +26,7 @@
     - service: device_tracker.icloud3_update
       data_template:
         account_name: gary_icloud
-        command: "{{ states.input_select.icloud3_commands.state }}"        
+        command: "{{ states.input_select.icloud3_commands.state }}"
 
 - alias: iCloud Debug Command
   id: icloud3_debug_command

--- a/custom_components/icloud3/sample-automations-scripts/cov_garage_door.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/cov_garage_door.yaml
@@ -1,10 +1,13 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:comments-indentation
+
 #########################################################
 #
 #   GARAGE DOOR ZWAVE SWITCH VIA SMARTTHINGS
 #
 #########################################################
 
-#---- Garage Door Z-Wave switch ----------------------------
+# --- Garage Door Z-Wave switch ----------------------------
 
 - platform: template
   covers:
@@ -39,5 +42,3 @@
 #        {% else %}
 #          mdi:arrow-expand-up
 #        {% endif %}
-          
-          

--- a/custom_components/icloud3/sample-automations-scripts/customize.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/customize.yaml
@@ -1,3 +1,6 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:line-length
+
 #########################################################
 #
 #   LOCATION AND DEVICE TRACKER ENTITIES
@@ -8,7 +11,7 @@ device_tracker.gary:
   entity_picture: /local/gary.png
 device_tracker.gary_iphone:
   friendly_name: Gary
-   
+
 #########################################################
 #
 #   GARAGE DOOR ENTITIES
@@ -21,12 +24,12 @@ sensor.garage_door_battery:
   friendly_name: Garage Door Battery Level
   icon: mdi:battery
   unit_of_measurement: '%'
-  
+
 sensor.garage_door:
   friendly_name: Garage Door
   icon: mdi:garage
   homebridge_visible: false
-  
+
 switch.garage_door:
   friendly_name: Garage Door Switch
   emulated_hue_hidden: false
@@ -35,9 +38,9 @@ cover.garage_door:
   friendly_name: Garage Door
   emulated_hue_hidden: false
   templates:
-   icon_color: "if (entities['switch.garage_door'].state === 'on') return 'red'; else if (entities['sensor.garage_door'].state === 'Open') return 'red'; else return 'dodgerblue';"
-   state:      "if (entities['sensor.garage_door'].state === 'Open') return 'Lower'; else return 'Raise';"
-   icon:       "if (entities['switch.garage_door'].state === 'on') return 'mdi:cached'; else if (entities['sensor.garage_door'].state === 'Open') return 'mdi:arrow-expand-down'; else return 'mdi:arrow-expand-up';"
+    icon_color: "if (entities['switch.garage_door'].state === 'on') return 'red'; else if (entities['sensor.garage_door'].state === 'Open') return 'red'; else return 'dodgerblue';"
+    state: "if (entities['sensor.garage_door'].state === 'Open') return 'Lower'; else return 'Raise';"
+    icon: "if (entities['switch.garage_door'].state === 'on') return 'mdi:cached'; else if (entities['sensor.garage_door'].state === 'Open') return 'mdi:arrow-expand-down'; else return 'mdi:arrow-expand-up';"
 
 #########################################################
 #
@@ -48,16 +51,14 @@ input_boolean.gary_driving_flag:
   friendly_name: Gary Driving Flag
   templates:
     icon_color: "if (state === 'on') return 'red'; else return 'dodgerblue';"
-    icon:       "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
+    icon: "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
 
 input_boolean.gary_far_away_flag:
   friendly_name: Gary Far Away Flag
   templates:
     icon_color: "if (state === 'on') return 'red'; else return 'dodgerblue';"
-    icon:       "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
+    icon: "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
 
 sensor.someone_home_flag_formatted:
   friendly_name: Someone Home Flag
   icon: mdi:home
-  
- 

--- a/custom_components/icloud3/sample-automations-scripts/device_tracker.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/device_tracker.yaml
@@ -1,10 +1,13 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:comments-indentation
+
 #########################################################
 #
 #   DEVICE_TRACKERS
 #
 #########################################################
 
-#----  iCloud iPhone Location Services ------------------------
+# ---  iCloud iPhone Location Services ------------------------
 device_tracker:
   - platform: icloud3
     username: gary-fmf-acct@email.com
@@ -14,15 +17,15 @@ device_tracker:
       - lillian_iphone > lillian-icloud-acct@email.com, lillian.jpg
 
 
-#----- Second instance of iCloud3 ----- 
+# ----- Second instance of iCloud3 -----
 #  - platform: icloud3
 #    username: sydney-fmf-acct@email.com
 #    password: sydney-fmf-password
 #    track_devices:
 #      - sydney > sydney-icloud-acct@email.com, sydney.png
-  
-  
-#----- Other Configuration Variables -----
+
+
+# ---- Other Configuration Variables -----
 #    group: family
 
 #    inzone_interval: '2 hrs'
@@ -45,4 +48,3 @@ device_tracker:
 #    exclude_sensors: cnt,lupdt,zon3,lzon3,alt
 
 #    log_level: debug
-  

--- a/custom_components/icloud3/sample-automations-scripts/ib_home_away_flags.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/ib_home_away_flags.yaml
@@ -1,15 +1,15 @@
+# yamllint disable rule:document-start
 
-#----- Gary Home Flags -------------------
+# ---- Gary Home Flags -------------------
 #   This is set in Automation_old>home_away>Set Gary Driving Flag (Turn On)
 #   and reset in Automation_old>home_away>Set Gary Arrive Home
 gary_driving_flag:
   name: Gary Driving Flag
-  
+
 gary_far_away_flag:
   name: Gary Far Away Flag
-  
+
 gary_iphone_zone_change:
   name: Gary Zone Change
   icon: mdi:checkbox-marked-outline
-  initial: off
- 
+  initial: 'off'

--- a/custom_components/icloud3/sample-automations-scripts/is_icloud.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/is_icloud.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   IPHONE/ICLOUD ATTRIBUTE INPUT SELECTS
@@ -13,7 +15,7 @@ icloud3_commands:
     - Pause garyiphone
     - Resume garyiphone
   icon: mdi:apple-keyboard-command
-  
+
 icloud3_set_interval:
   name: iCloud Set Interval
   options:
@@ -40,4 +42,3 @@ icloud3_debug_commands:
     - debug gps
     - debug old
   icon: mdi:android-debug-bridge
- 

--- a/custom_components/icloud3/sample-automations-scripts/sc_garage_door.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/sc_garage_door.yaml
@@ -1,3 +1,6 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:line-length
+
 #########################################################
 #
 #   SCRIPTS
@@ -7,36 +10,36 @@
 #
 #########################################################
 
-#--------------------------------------------------------------- 
+# --------------------------------------------------------------
 #   If garage door is closed and Gary's driving flag is true
 #   open the Garage Door, turn off Gary's driving flag and notify Gary
 #   Called from automation_old/garage_door.yaml
-#--------------------------------------------------------------- 
+# --------------------------------------------------------------
 open_garage_door:
   alias: 'Open Garage Door'
   sequence:
-    
-    #- condition: state
-    #  entity_id: input_boolean.ha_started_flag
-    #  state: 'on'
-      
+
+    # - condition: state
+    #   entity_id: input_boolean.ha_started_flag
+    #   state: 'on'
+
     - condition: state
       entity_id: sensor.garage_door
       state: 'Closed'
-      
-    - condition: template 
+
+    - condition: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state  | float <= 0.30}}'
-   
+
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'on'
- 
+
     - condition: state
       entity_id: input_boolean.gary_far_away_flag
       state: 'off'
-      
+
     - service: script.show_garage_door_status
-  
+
     - service: switch.turn_on
       entity_id: switch.garage_door
 

--- a/custom_components/icloud3/sample-automations-scripts/sc_home_away_gary.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/sc_home_away_gary.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 ##############################################################
 #
 #   HOME/AWAY SCRIPTS - Gary
@@ -10,71 +12,71 @@ gary_status:
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Status'
-        message: 'Zone={{states.sensor.gary_iphone_zone.state}}, 
-                  Zone1={{states.sensor.gary_iphone_zone_name1.state}}, 
-                  Zone2={{states.sensor.gary_iphone_zone_name2.state}}, 
+        message: 'Zone={{states.sensor.gary_iphone_zone.state}},
+                  Zone1={{states.sensor.gary_iphone_zone_name1.state}},
+                  Zone2={{states.sensor.gary_iphone_zone_name2.state}},
                   Distance={{states.sensor.gary_iphone_zone_distance.state}},
                   DriveFlag={{states.input_boolean.gary_driving_flag.state}},
                   FarFlag={{states.input_boolean.gary_far_away_flag.state}}'
-  
-#-------------------------------------------------------------
+
+# ------------------------------------------------------------
 #   Arrive Home
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 gary_arrives_home:
   alias: 'Gary Arrives Home'
   sequence:
-    #Open garage door if driving flag is on
-    - service: script.open_garage_door 
-    
-    #Turn off 'Away' flags
+    # Open garage door if driving flag is on
+    - service: script.open_garage_door
+
+    # Turn off 'Away' flags
     - service: input_boolean.turn_off
       entity_id: input_boolean.gary_driving_flag
     - service: input_boolean.turn_off
       entity_id: input_boolean.gary_far_away_flag
-    
-    #Change Gary badge to home
+
+    # Change Gary badge to home
     - service: mqtt.publish
       data_template:
-        topic: 'location/gary' 
+        topic: 'location/gary'
         payload: 'home'
-        
-    #If already home, do not issue 'zone home' command
+
+    # If already home, do not issue 'zone home' command
     - condition: template
       value_template: '{{states.device_tracker.gary_iphone.state != "home"}}'
-    
-    #Issue 'zone home' command
+
+    # Issue 'zone home' command
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone home'
+        device_name: gary_iphone
+        command: 'zone home'
 
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 #   Leave Home
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 gary_leaves_home:
   alias: 'Gary Leaves Home'
   sequence:
-    #Change Gary badge to Away
+    # Change Gary badge to Away
     - service: mqtt.publish
       data_template:
-        topic: 'location/gary' 
+        topic: 'location/gary'
         payload: 'not_home'
-       
-#-------------------------------------------------------------
+
+# ------------------------------------------------------------
 #    Leave Other Zone
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 gary_leaves_zone:
   alias: 'Gary Leaves Zone'
   sequence:
-    #Change Gary badge to Away
+    # Change Gary badge to Away
     - service: mqtt.publish
       data_template:
-        topic: 'location/gary' 
+        topic: 'location/gary'
         payload: 'not_home'
- 
-#-------------------------------------------------------------
+
+# ------------------------------------------------------------
 #   Send Message to Gary - Central Notify Command
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 notify_gary_iphone:
   alias: 'Send Message to Gary'
   sequence:
@@ -82,7 +84,7 @@ notify_gary_iphone:
       data_template:
         title: "{{ title }} (IOS)"
         message: "{{ message }}"
-          
+
 #    - service: notify.mobile_app_gary_iphone
 #      data_template:
 #        title: "{{ title }} (mobile_app)"

--- a/custom_components/icloud3/sample-automations-scripts/sc_icloud3.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/sc_icloud3.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   DEVICE_TRACKER/ICLOUD3.PY CUSTOM COMPONENT SUPPORT SCRIPTS
@@ -5,23 +7,23 @@
 #########################################################
 
 
-#--------------------------------------------------------------
+# ------------------------------------------------------------
 #   GENERAL ICLOUD COMMANDS
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 icloud3_command_restart:
   alias: 'Restart iCloud (Command)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: restart
-       
+
 icloud3_command_resume_polling:
   alias: 'Resume Polling'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: resume
-        
+
 icloud3_command_pause_polling:
   alias: 'Pause Polling'
   sequence:
@@ -35,35 +37,35 @@ icloud3_command_toggle_waze:
     - service: device_tracker.icloud3_update
       data:
         command: waze toggle
-        
+
 icloud3_command_reset_waze_range:
   alias: 'Reset Waze Range'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: waze reset_range
-        
+
 icloud3_update_location:
   alias: 'Update Location (all)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: location
-#------------------------------------------------------------          
+# -----------------------------------------------------------
 icloud3_set_interval_1_min:
   alias: 'Interval - 1 min'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: 1
-        
+
 icloud3_set_interval_5_min:
   alias: 'Interval - 5 min'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: 5
-               
+
 icloud3_set_interval_15_min:
   alias: 'Interval - 15 min'
   sequence:
@@ -77,48 +79,47 @@ icloud3_set_interval_30_min:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: '30 min'
- 
+
 icloud3_set_interval_1_hrs:
   alias: 'Interval -  1 hrs'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: '1 hr'
-                
+
 icloud3_set_interval_5_hrs:
   alias: 'Interval -   5 hrs'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: '5 hr'
-  
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Set iCloud commands for Gary
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 icloud3_command_resume_polling_gary:
   alias: 'Resume (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: gary_iphone
-        command:     resume
-        
+        command: resume
+
 icloud3_command_pause_polling_gary:
   alias: 'Pause (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: gary_iphone
-        command:     pause
-              
+        command: pause
+
 icloud3_set_interval_10_min_gary:
   alias: 'Interval - 10 min (Gary)'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         device_name: gary_iphone
-        interval:   '10 min'
+        interval: '10 min'
 
 icloud3_set_interval_2_min_gary:
   alias: 'Interval -  1 min (Gary)'
@@ -126,15 +127,15 @@ icloud3_set_interval_2_min_gary:
     - service: device_tracker.icloud3_set_interval
       data:
         device_name: gary_iphone
-        interval:   '1 min'
-        
+        interval: '1 min'
+
 icloud3_lost_iphone_gary:
   alias: 'Find Lost Phone Alert (Gary)'
   sequence:
     - service: device_tracker.icloud3_lost_iphone
       data:
         device_name: gary_iphone
-       
+
     - service: script.notify_gary_iphone
       data_template:
         title: 'Lost iPhone Notification'
@@ -146,33 +147,34 @@ icloud3_update_location_gary:
     - service: device_tracker.icloud3_update
       data:
         device_name: gary_iphone
-        command:     location
-#--------------------------------------------------------------
+        command: location
+
+# -------------------------------------------------------------
 #   Set iCloud polling interval for Lillian (lillian_icloud account)
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 icloud3_command_resume_polling_lillian:
   alias: 'Resume (Lillian)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: lillian_icloud
-        command:     resume
-        
+        command: resume
+
 icloud3_command_pause_polling_lillian:
   alias: 'Pause (Lillian)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: lillian_icloud
-        command:     pause
- 
+        command: pause
+
 icloud3_set_interval_10_min_lillian:
   alias: 'Interval - 10 min (Lillian)'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         device_name: lillian_iphone
-        interval:    '10 min'
+        interval: '10 min'
 
 icloud3_set_interval_1_min_lillian:
   alias: 'Interval - 1 min (Lillian)'
@@ -181,7 +183,7 @@ icloud3_set_interval_1_min_lillian:
       data:
         device_name: lillian_iphone
         interval: 1
-        
+
 icloud3_lost_iphone_lillian:
   alias: 'Find Lost Phone Alert (Lillian)'
   sequence:
@@ -195,13 +197,13 @@ icloud3_lost_iwatch_lillian:
     - service: device_tracker.icloud3_lost_iphone
       data:
         device_name: lillian_iwatch
-        
+
 icloud3_lost_iphone_invalid:
   alias: 'Find Lost Phone Alert (Invalid)'
   sequence:
     - service: device_tracker.icloud3_lost_iphone
       data:
-        device_name: invalid_iphone 
+        device_name: invalid_iphone
 
 icloud3_update_location_lillian:
   alias: 'Update Location (Lillian)'
@@ -209,51 +211,52 @@ icloud3_update_location_lillian:
     - service: device_tracker.icloud3_update
       data:
         device_name: lillian_iphone
-        command:     location
-#--------------------------------------------------------------
+        command: location
+
+# -------------------------------------------------------------
 #   ZONE COMMANDS
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 
 icloud3_command_gary_iphone_zone_home:
   alias: 'Set Zone Home (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone home'
+        device_name: gary_iphone
+        command: 'zone home'
 
 icloud3_command_gary_iphone_zone_quail:
   alias: 'Set Zone Quail (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone Quail'
-        
+        device_name: gary_iphone
+        command: 'zone Quail'
+
 icloud3_command_gary_iphone_zone_not_home:
   alias: 'Set Zone Away (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone not_home'
-        
+        device_name: gary_iphone
+        command: 'zone not_home'
+
 icloud3_command_lillian_iphone_zone_home:
   alias: 'Set Zone Home (Lillian/gary_icloud)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  lillian_iphone
-        command:     'zone home'
-        
+        device_name: lillian_iphone
+        command: 'zone home'
+
 icloud3_command_lillian_iphone_zone_not_home:
   alias: Set Zone Away (Lillian/gary_icloud)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  lillian_iphone
-        command:     'zone not_home'
-        
+        device_name: lillian_iphone
+        command: 'zone not_home'
+
 icloud3_gary_iphone_see_away:
   alias: 'Set Away via device_tracker.see svc call (Gary)'
   sequence:
@@ -261,26 +264,25 @@ icloud3_gary_iphone_see_away:
       data:
         dev_id: gary_iphone
         location_name: 'not_home'
-        
- 
 
-#--------------------------------------------------------------
+
+# -------------------------------------------------------------
 #   INFORMATION COMMANDS
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 icloud3_command_loglevel_debug:
   alias: 'LogLevel-Debug Info to HA Log (Toggle)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: log_level debug
-        
+
 icloud3_command_loglevel_intervalcalc:
   alias: 'LogLevel-Interval Calc (Toggle)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: log_level _intervalcalc
-        
+
 icloud3_command_loglevel_eventlog:
   alias: 'LogLevel-Event Log (Toggle)'
   sequence:
@@ -294,7 +296,7 @@ icloud3_command_loglevel_debug_eventlog:
     - service: device_tracker.icloud3_update
       data:
         command: log_level debug, eventlog
- 
+
 icloud3_command_loglevel_intervalcalc_eventlog:
   alias: 'LogLevel-Interval Calc & EventLog (Toggle)'
   sequence:
@@ -308,5 +310,3 @@ icloud3_command_loglevel_info:
     - service: device_tracker.icloud3_update
       data:
         command: log_level info
-
-

--- a/custom_components/icloud3/sample-automations-scripts/sn_badges.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/sn_badges.yaml
@@ -1,26 +1,28 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   BADGE TEMPLATE SENSORS
 #
 #########################################################
-#--- Gary/Lillian location badge --------------------
+
+# -- Gary/Lillian location badge --------------------
 - platform: template
   sensors:
-    gary_iphone_badge_x:  
+    gary_iphone_badge_x:
       friendly_name: Gary
       value_template: '{{states.sensor.garyc_badge.state}}'
       entity_picture_template: /local/gary.png
-   
-#--- Garage Door Open/Closed --------------------
+
+# -- Garage Door Open/Closed --------------------
 - platform: template
   sensors:
     garage_door_badge:
       value_template: >-
-        {{states.sensor.garage_door.state}} 
+        {{states.sensor.garage_door.state}}
       entity_picture_template: >-
         {% if states.sensor.garage_door.state == "Closed" %}
           /local/garage-door-closed.png
         {% else %}
-          /local/garage-door-open.png 
+          /local/garage-door-open.png
         {% endif %}
-              

--- a/custom_components/icloud3/sample-automations-scripts/sn_garage_door.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/sn_garage_door.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   GARAGE DOOR MQTT SENSOR
@@ -14,4 +16,3 @@
   name: "garage_door_battery"
   state_topic: "smartthings/Garage Door/battery/state"
   device_class: battery
-  

--- a/custom_components/icloud3/sample-automations-scripts/sw_garage_door.yaml
+++ b/custom_components/icloud3/sample-automations-scripts/sw_garage_door.yaml
@@ -1,10 +1,12 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   GARAGE DOOR ZWAVE SWITCH VIA SMARTTHINGS
 #
 #########################################################
 
-#---- Garage Door Z-Wave switch ----------------------------
+# --- Garage Door Z-Wave switch ----------------------------
 - platform: mqtt
   name: "garage_door"
   state_topic: "smartthings/Garage Door/switch/state"
@@ -12,5 +14,3 @@
   payload_on: "on"
   payload_off: "off"
   retain: false
-         
-          

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace-gary-2-zones-4x3.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace-gary-2-zones-4x3.yaml
@@ -1,131 +1,131 @@
+# yamllint disable rule:document-start
 
-#----------------------------------------------- Gary (Home Zone)
-  - title: Location (Gary)
-    icon: mdi:cellphone-iphone
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: glance
-            title: Location Info - Gary
-            column_width: 25%
-            entities:
-              - entity: device_tracker.gary_iphone
-                name: Gary
-              - entity: sensor.gary_iphone_interval
-                name: Interval
-                icon: mdi:clock-start
-              - entity: sensor.gary_iphone_travel_time
-                name: TravTime
-                icon: mdi:clock-outline
-              - entity: sensor.gary_iphone_zone_distance
-                name: HomeDist
-                icon: mdi:map-marker-distance 
-         
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.gary_iphone_waze_distance
-                name: WazeDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.gary_iphone_calc_distance
-                name: CalcDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.gary_iphone_dir_of_travel
-                name: Direction
-                icon: mdi:compass-outline
-              - entity: input_boolean.gary_driving_flag
-                name: Driving
-                tap_action:  
-                  action: toggle
+# -------------------------------------------- Gary (Home Zone)
+- title: Location (Gary)
+  icon: mdi:cellphone-iphone
+  cards:
+    - type: vertical-stack
+      cards:
+        - type: glance
+          title: Location Info - Gary
+          column_width: 25%
+          entities:
+            - entity: device_tracker.gary_iphone
+              name: Gary
+            - entity: sensor.gary_iphone_interval
+              name: Interval
+              icon: mdi:clock-start
+            - entity: sensor.gary_iphone_travel_time
+              name: TravTime
+              icon: mdi:clock-outline
+            - entity: sensor.gary_iphone_zone_distance
+              name: HomeDist
+              icon: mdi:map-marker-distance
 
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.gary_iphone_last_located
-                name: Located
-                icon: mdi:history
-              - entity: sensor.gary_iphone_last_update
-                name: LastUpdt
-                icon: mdi:history
-              - entity: sensor.gary_iphone_next_update
-                name: NextUpdt
-                icon: mdi:update
-              - entity: sensor.gary_iphone_poll_count
-                name: PollCount
-                icon: mdi:counter
-                tap_action: 
-                  action: call-service
-                  service: script.icloud3_command_event_log_gary
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.gary_iphone_waze_distance
+              name: WazeDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.gary_iphone_calc_distance
+              name: CalcDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.gary_iphone_dir_of_travel
+              name: Direction
+              icon: mdi:compass-outline
+            - entity: input_boolean.gary_driving_flag
+              name: Driving
+              tap_action:
+                action: toggle
 
-          - type: entities
-            entities:
-              - entity: sensor.gary_iphone_info
-                name: Info
-                icon: mdi:information-outline 
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.gary_iphone_last_located
+              name: Located
+              icon: mdi:history
+            - entity: sensor.gary_iphone_last_update
+              name: LastUpdt
+              icon: mdi:history
+            - entity: sensor.gary_iphone_next_update
+              name: NextUpdt
+              icon: mdi:update
+            - entity: sensor.gary_iphone_poll_count
+              name: PollCount
+              icon: mdi:counter
+              tap_action:
+                action: call-service
+                service: script.icloud3_command_event_log_gary
 
-#----------------------------------------------- Gary (Warehouse Zone)
-      - type: vertical-stack
-        cards:
-          - type: glance
-            title: Location Info - Gary (Warehouse)
-            column_width: 25%
-            entities:
-              - entity: device_tracker.gary_iphone
-                name: Gary
-              - entity: sensor.whse_gary_iphone_interval
-                name: Interval
-                icon: mdi:clock-start
-              - entity: sensor.whse_gary_iphone_travel_time
-                name: TravTime
-                icon: mdi:clock-outline
-              - entity: sensor.whse_gary_iphone_zone_distance
-                name: WhseDist
-                icon: mdi:map-marker-distance 
-         
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.whse_gary_iphone_waze_distance
-                name: WazeDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.whse_gary_iphone_calc_distance
-                name: CalcDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.whse_gary_iphone_dir_of_travel
-                name: Direction
-                icon: mdi:compass-outline
-              - entity: input_boolean.gary_driving_flag
-                name: Driving
-                tap_action:  
-                  action: toggle
+        - type: entities
+          entities:
+            - entity: sensor.gary_iphone_info
+              name: Info
+              icon: mdi:information-outline
 
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.whse_gary_iphone_last_located
-                name: Located
-                icon: mdi:history
-              - entity: sensor.whse_gary_iphone_last_update
-                name: LastUpdt
-                icon: mdi:history
-              - entity: sensor.whse_gary_iphone_next_update
-                name: NextUpdt
-                icon: mdi:update
-              - entity: sensor.whse_gary_iphone_poll_count
-                name: PollCount
-                icon: mdi:counter
-                tap_action: 
-                  action: call-service
-                  service: script.icloud3_command_event_log_gary
- 
-          - type: entities
-            entities:
-              - entity: sensor.whse_gary_iphone_info
-                name: Info
-                icon: mdi:information-outline 
+    # ---------------------------------------- Gary (Warehouse Zone)
+    - type: vertical-stack
+      cards:
+        - type: glance
+          title: Location Info - Gary (Warehouse)
+          column_width: 25%
+          entities:
+            - entity: device_tracker.gary_iphone
+              name: Gary
+            - entity: sensor.whse_gary_iphone_interval
+              name: Interval
+              icon: mdi:clock-start
+            - entity: sensor.whse_gary_iphone_travel_time
+              name: TravTime
+              icon: mdi:clock-outline
+            - entity: sensor.whse_gary_iphone_zone_distance
+              name: WhseDist
+              icon: mdi:map-marker-distance
 
-          - type: entities
-            entities:
-              - script.icloud3_update_location_gary
-              - script.homeassistant_restart
-              
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.whse_gary_iphone_waze_distance
+              name: WazeDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.whse_gary_iphone_calc_distance
+              name: CalcDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.whse_gary_iphone_dir_of_travel
+              name: Direction
+              icon: mdi:compass-outline
+            - entity: input_boolean.gary_driving_flag
+              name: Driving
+              tap_action:
+                action: toggle
+
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.whse_gary_iphone_last_located
+              name: Located
+              icon: mdi:history
+            - entity: sensor.whse_gary_iphone_last_update
+              name: LastUpdt
+              icon: mdi:history
+            - entity: sensor.whse_gary_iphone_next_update
+              name: NextUpdt
+              icon: mdi:update
+            - entity: sensor.whse_gary_iphone_poll_count
+              name: PollCount
+              icon: mdi:counter
+              tap_action:
+                action: call-service
+                service: script.icloud3_command_event_log_gary
+
+        - type: entities
+          entities:
+            - entity: sensor.whse_gary_iphone_info
+              name: Info
+              icon: mdi:information-outline
+
+        - type: entities
+          entities:
+            - script.icloud3_update_location_gary
+            - script.homeassistant_restart

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace-home-whse_5x2.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace-home-whse_5x2.yaml
@@ -1,3 +1,4 @@
+# yamllint disable rule:document-start
 
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
@@ -24,11 +25,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: Home
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -47,20 +48,20 @@ views:
               - entity: sensor.gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
-              
+
           - type: horizontal-stack
             cards:
-            - type: entities
-              entities:
-                - entity: sensor.gary_iphone_info
-                  name: Info
-                  icon: mdi:information-outline 
+              - type: entities
+                entities:
+                  - entity: sensor.gary_iphone_info
+                    name: Info
+                    icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
-              
+
       - type: vertical-stack
         cards:
           - type: glance
@@ -77,11 +78,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.whse_gary_iphone_zone_distance
                 name: Whse
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.whse_gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -100,10 +101,9 @@ views:
               - entity: sensor.whse_gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
- 
+
           - type: entities
             entities:
               - entity: sensor.whse_gary_iphone_info
                 name: Info
-                icon: mdi:information-outline 
-
+                icon: mdi:information-outline

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_all.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_all.yaml
@@ -1,15 +1,16 @@
+# yamllint disable rule:document-start
 
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
     type: js
-   
+
 title: Home
 views:
 
-#=============================================================
+  # ==========================================================
   - title: Main
     icon: mdi:star-outline
-    cards:        
+    cards:
       - type: vertical-stack
         cards:
           - type: glance
@@ -22,7 +23,7 @@ views:
                 name: Lillian
               - entity: sensor.garage_door_badge
                 name: Garage
-               
+
       - type: map
         entities:
           - device_tracker.gary_iphone
@@ -30,8 +31,8 @@ views:
           - zone.home
           - zone.quail
           - zone.whse
-          
-#=============================================================
+
+  # ==========================================================
   - title: Location (Gary)
     icon: mdi:cellphone-iphone
     cards:
@@ -51,11 +52,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -74,21 +75,21 @@ views:
               - entity: sensor.gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
-              
+
           - type: horizontal-stack
             cards:
-            - type: entities
-              entities:
-                - entity: sensor.gary_iphone_info
-                  name: Info
-                  icon: mdi:information-outline 
+              - type: entities
+                entities:
+                  - entity: sensor.gary_iphone_info
+                    name: Info
+                    icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
 
-#-------------------------------------------------------------            
+      # ------------------------------------------------------
       - type: vertical-stack
         cards:
           - type: glance
@@ -105,11 +106,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.lillian_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.lillian_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -132,19 +133,19 @@ views:
             entities:
               - entity: sensor.lillian_iphone_info
                 name: Info
-                icon: mdi:information-outline 
+                icon: mdi:information-outline
 
-#=============================================================
+  # ==========================================================
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log
 
-#============================================================= 
+  # ==========================================================
   - title: iCloud Commands
     icon: mdi:cloud-upload-outline
-    cards: 
+    cards:
       - type: entities
         title: iCloud3 Device Tracker Commands
         show_header_toggle: false
@@ -164,11 +165,11 @@ views:
           - script.icloud3_command_reset_waze_range
           - script.icloud3_lost_iphone_invalid
           - script.icloud3_update_location
-          
+
       - type: entities
         title: iCloud3 Commands - Gary
         show_header_toggle: false
-        entities:   
+        entities:
           - script.icloud3_command_resume_polling_gary
           - script.icloud3_command_pause_polling_gary
           - script.icloud3_set_interval_2_min_gary
@@ -178,24 +179,21 @@ views:
           - script.icloud3_command_gary_iphone_zone_home
           - script.icloud3_update_location_gary
           - script.icloud3_lost_iphone_gary
-          
+
       - type: entities
         title: iCloud3 Service Calls
         show_header_toggle: false
-        entities:    
+        entities:
           - script.icloud3_lost_iphone_lillian
           - script.icloud3_lost_iwatch_lillian
           - script.icloud3_gary_iphone_see_away
           - script.icloud3_update_location_lillian
-          
+
       - type: entities
         entities:
-        - script.icloud3_command_loglevel_debug
-        - script.icloud3_command_loglevel_intervalcalc
-        - script.icloud3_command_loglevel_eventlog
-        - script.icloud3_command_loglevel_info
-        - script.icloud3_command_loglevel_debug_eventlog
-        - script.icloud3_command_loglevel_intervalcalc_eventlog
-        
-
-         
+          - script.icloud3_command_loglevel_debug
+          - script.icloud3_command_loglevel_intervalcalc
+          - script.icloud3_command_loglevel_eventlog
+          - script.icloud3_command_loglevel_info
+          - script.icloud3_command_loglevel_debug_eventlog
+          - script.icloud3_command_loglevel_intervalcalc_eventlog

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_commands.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_commands.yaml
@@ -1,55 +1,56 @@
-  - title: iCloud Commands
-    icon: mdi:cloud-upload-outline
-    cards: 
-      - type: entities
-        title: iCloud3 Device Tracker Commands
-        show_header_toggle: false
-        entities:
-          - script.icloud3_command_resume_polling
-          - script.icloud3_command_pause_polling
-          - script.icloud3_command_restart
-          - type: divider
-          - script.icloud3_set_interval_1_min
-          - script.icloud3_set_interval_5_min
-          - script.icloud3_set_interval_15_min
-          - script.icloud3_set_interval_30_min
-          - script.icloud3_set_interval_1_hrs
-          - script.icloud3_set_interval_5_hrs
-          - type: divider
-          - script.icloud3_command_toggle_waze
-          - script.icloud3_command_reset_waze_range
-          - script.icloud3_lost_iphone_invalid
-          - script.icloud3_update_location
-          
-      - type: entities
-        title: iCloud3 Commands - Gary
-        show_header_toggle: false
-        entities:   
-          - script.icloud3_command_resume_polling_gary
-          - script.icloud3_command_pause_polling_gary
-          - script.icloud3_set_interval_2_min_gary
-          - script.icloud3_set_interval_10_min_gary
-          - script.icloud3_set_interval_1_min_lillian
-          - script.icloud3_set_interval_10_min_lillian
-          - script.icloud3_command_gary_iphone_zone_home
-          - script.icloud3_update_location_gary
-          - script.icloud3_lost_iphone_gary
-          
-      - type: entities
-        title: iCloud3 Service Calls, log_level Cmds
-        show_header_toggle: false
-        entities:    
-          - script.icloud3_lost_iphone_lillian
-          - script.icloud3_lost_iwatch_lillian
-          - script.icloud3_gary_iphone_see_away
-          - script.icloud3_update_location_lillian
-          
-      - type: entities
-        entities:
+# yamllint disable rule:document-start
+
+- title: iCloud Commands
+  icon: mdi:cloud-upload-outline
+  cards:
+    - type: entities
+      title: iCloud3 Device Tracker Commands
+      show_header_toggle: false
+      entities:
+        - script.icloud3_command_resume_polling
+        - script.icloud3_command_pause_polling
+        - script.icloud3_command_restart
+        - type: divider
+        - script.icloud3_set_interval_1_min
+        - script.icloud3_set_interval_5_min
+        - script.icloud3_set_interval_15_min
+        - script.icloud3_set_interval_30_min
+        - script.icloud3_set_interval_1_hrs
+        - script.icloud3_set_interval_5_hrs
+        - type: divider
+        - script.icloud3_command_toggle_waze
+        - script.icloud3_command_reset_waze_range
+        - script.icloud3_lost_iphone_invalid
+        - script.icloud3_update_location
+
+    - type: entities
+      title: iCloud3 Commands - Gary
+      show_header_toggle: false
+      entities:
+        - script.icloud3_command_resume_polling_gary
+        - script.icloud3_command_pause_polling_gary
+        - script.icloud3_set_interval_2_min_gary
+        - script.icloud3_set_interval_10_min_gary
+        - script.icloud3_set_interval_1_min_lillian
+        - script.icloud3_set_interval_10_min_lillian
+        - script.icloud3_command_gary_iphone_zone_home
+        - script.icloud3_update_location_gary
+        - script.icloud3_lost_iphone_gary
+
+    - type: entities
+      title: iCloud3 Service Calls, log_level Cmds
+      show_header_toggle: false
+      entities:
+        - script.icloud3_lost_iphone_lillian
+        - script.icloud3_lost_iwatch_lillian
+        - script.icloud3_gary_iphone_see_away
+        - script.icloud3_update_location_lillian
+
+    - type: entities
+      entities:
         - script.icloud3_command_loglevel_debug
         - script.icloud3_command_loglevel_intervalcalc
         - script.icloud3_command_loglevel_eventlog
         - script.icloud3_command_loglevel_info
         - script.icloud3_command_loglevel_debug_eventlog
         - script.icloud3_command_loglevel_intervalcalc_eventlog
-        

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_event_log.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_event_log.yaml
@@ -1,14 +1,15 @@
+# yamllint disable rule:document-start
 
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
     type: js
-   
+
 title: Home
 views:
 
-#=============================================================
+  # ==========================================================
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_gc-5x2.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_gc-5x2.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 title: Home
 views:
   - title: Location (Gary)
@@ -19,11 +21,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: Home
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -42,17 +44,16 @@ views:
               - entity: sensor.gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
-              
+
           - type: horizontal-stack
             cards:
-            - type: entities
-              entities:
-                - entity: sensor.gary_iphone_info
-                  name: Info
-                  icon: mdi:information-outline 
+              - type: entities
+                entities:
+                  - entity: sensor.gary_iphone_info
+                    name: Info
+                    icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
-

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_gc_4x3.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_gc_4x3.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 title: Home
 views:
   - title: Location
@@ -19,8 +21,8 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
-         
+                icon: mdi:map-marker-distance
+
           - type: glance
             column_width: 25%
             entities:
@@ -35,7 +37,7 @@ views:
                 icon: mdi:compass-outline
               - entity: input_boolean.gary_driving_flag
                 name: Driving
-                tap_action:  
+                tap_action:
                   action: toggle
 
           - type: glance
@@ -53,21 +55,21 @@ views:
               - entity: sensor.gary_iphone_poll_count
                 name: PollCount
                 icon: mdi:counter
- 
+
           - type: entities
             entities:
               - entity: sensor.gary_iphone_info
                 name: Info
-                icon: mdi:information-outline 
+                icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
-              
-#----------------------------------------------------------------------
+
+  # -------------------------------------------------------------------
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log

--- a/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_gc_lc_4x3.yaml
+++ b/custom_components/icloud3/sample-lovelace-cards/ui-lovelace_gc_lc_4x3.yaml
@@ -1,9 +1,10 @@
+# yamllint disable rule:document-start
 
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
     type: js
 
-    
+
 title: Home
 views:
   - title: Location (Gary)
@@ -25,8 +26,8 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
-         
+                icon: mdi:map-marker-distance
+
           - type: glance
             column_width: 25%
             entities:
@@ -41,7 +42,7 @@ views:
                 icon: mdi:compass-outline
               - entity: input_boolean.gary_driving_flag
                 name: Driving
-                tap_action:  
+                tap_action:
                   action: toggle
 
           - type: glance
@@ -59,13 +60,13 @@ views:
               - entity: sensor.gary_iphone_poll_count
                 name: PollCount
                 icon: mdi:counter
-  
+
           - type: entities
             entities:
               - entity: sensor.gary_iphone_info
                 name: Info
-                icon: mdi:information-outline 
-              
+                icon: mdi:information-outline
+
       - type: vertical-stack
         cards:
           - type: glance
@@ -82,8 +83,8 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.lillian_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
-         
+                icon: mdi:map-marker-distance
+
           - type: glance
             column_width: 25%
             entities:
@@ -98,7 +99,7 @@ views:
                 icon: mdi:compass-outline
               - entity: input_boolean.lillian_driving_flag
                 name: Driving
-                tap_action:  
+                tap_action:
                   action: toggle
 
           - type: glance
@@ -122,11 +123,10 @@ views:
               - entity: sensor.lillian_iphone_info
                 name: Info
                 icon: mdi:information-outline
-       
-#=============================================================
+
+  # ==========================================================
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log
-

--- a/custom_components/icloud3/services.yaml
+++ b/custom_components/icloud3/services.yaml
@@ -1,3 +1,6 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:line-length
+
 icloud3_update:
   description: This service allows you to change the way iCloud3 operates.
   fields:
@@ -24,7 +27,7 @@ icloud3_restart:
     account_name:
       description: account_name of the iCloud3 custom component specified in the Configuration Variables section described at the beginning of this document. (Required)
       example: gary_icloud
-      
+
 icloud3_lost_iphone:
   description: This service will play the Lost iPhone sound on a specific device.
   fields:

--- a/sample-automations-scripts/au_garage_door.yaml
+++ b/sample-automations-scripts/au_garage_door.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   AUTOMATIONS_OLD
@@ -8,48 +10,48 @@
 #########################################################
 
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   If the Garage Door is open after 8pm, close it
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Close Garage Door (Open after 8pm)
   id: close_garage_door_after_8pm
   trigger:
     platform: time
     at: '20:00:00'
-    
+
   condition:
     condition: state
     entity_id: sensor.garage_door
     state: 'Open'
-    
+
   action:
     - service: switch.turn_on
       entity_id: switch.garage_door
-      
+
     - service: script.notify_gary_iphone
       data:
         title: Garage Door Closed
         message: After 8pm - Close Door Automation Triggered
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   If the Garage Door is open and no one is home, close it
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Close Garage Door (No One Home)
   id: close_garage_door_no_one_home
   trigger:
     platform: state
     entity_id: sensor.someone_home_flag
     to: 'all away'
-    
+
   condition:
     condition: state
     entity_id: sensor.garage_door
     state: 'Open'
-    
+
   action:
     - service: switch.turn_on
       entity_id: switch.garage_door
-      
+
     - service: script.notify_gary_iphone
       data:
         title: Garage Door Closed

--- a/sample-automations-scripts/au_home_away_gary.yaml
+++ b/sample-automations-scripts/au_home_away_gary.yaml
@@ -1,11 +1,14 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:line-length
+
 ################################################################
 #
 #   AUTOMATIONS_OLD - Gary Zone Automations
 #
 ################################################################
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Gary arrives home
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Arrives Home
   id: gary_arrives_home
   trigger:
@@ -15,84 +18,84 @@
 
     - platform: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float <= 0.2}}'
-      
-  condition: 
+
+  condition:
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'on'
-      
+
   action:
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Arrives Home'
-        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}' 
-            
+        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}'
+
     - service: script.gary_arrives_home
-    
-#--------------------------------------------------------------
+
+# -------------------------------------------------------------
 #   Gary leaves home zone
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Leaves Home
   id: gary_leaves_home
   trigger:
     - platform: state
       entity_id: sensor.gary_iphone_zone_name1
       to: 'Away'
-      
-  condition: 
+
+  condition:
     - condition: template
       value_template: '{{trigger.from_state.state == "Home"}}'
-      
+
     - condition: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 0}}'
-    
+
     - condition: state
       entity_id: input_boolean.ha_started_flag
-      state: 'on'    
+      state: 'on'
   action:
     - service: script.gary_leaves_home
- 
+
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Leaves Home'
-        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}' 
-        
+        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}'
+
     - service: script.gary_leaves_zone
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Gary leaves a zone
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Leaves Zone
   id: gary_leaves_zone
   trigger:
     - platform: state
       entity_id: sensor.gary_iphone_zone_name1
       to: 'Away'
-      
-  condition: 
+
+  condition:
     - condition: template
       value_template: '{{trigger.from_state.state != "Home"}}'
-      
+
     - condition: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 0}}'
-    
+
     - condition: state
       entity_id: input_boolean.ha_started_flag
-      state: 'on'    
+      state: 'on'
   action:
     - service: script.gary_leaves_zone
-        
+
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Leaves Zone'
-        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}' 
+        message: 'Zone: {{ trigger.from_state.state }} --> {{ trigger.to_state.state }}, Distance: {{ states.sensor.gary_iphone_zone_distance.state }}'
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Turn on Gary's Driving Flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Driving Flag Turn On
   id: gary_driving_flag_turn_on
-        
+
   trigger:
     - platform: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 2}}'
@@ -101,14 +104,14 @@
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'off'
-       
+
   action:
     - service: input_boolean.turn_on
       entity_id: input_boolean.gary_driving_flag
-         
-#--------------------------------------------------------------
+
+# -------------------------------------------------------------
 #   Turn off Gary's Driving Flag if Home for 15 minutes if still on
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Driving Flag Turn Off
   id: gary_driving_flag_turn_off
   trigger:
@@ -117,39 +120,39 @@
       to: 'home'
       for:
         minutes: 15
-    
+
   condition:
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'on'
-      
+
   action:
     - service: input_boolean.turn_off
       entity_id: input_boolean.gary_driving_flag
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Turn on Gary's Far Away Flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Far Away Flag Turn On
   id: gary_far_away_flag_turn_on
   trigger:
     - platform: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state | float > 5}}'
-      
+
   condition:
     - condition: state
       entity_id: input_boolean.gary_far_away_flag
       state: 'off'
-      
+
   action:
     - service: input_boolean.turn_on
       entity_id: input_boolean.gary_driving_flag
 
     - service: input_boolean.turn_on
       entity_id: input_boolean.gary_far_away_flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   Turn off Gary's Far Away Flag
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 - alias: Gary Far Away Flag Turn Off
   id: gary_far_away_flag_turn_off
   trigger:
@@ -160,8 +163,7 @@
     - condition: state
       entity_id: input_boolean.gary_far_away_flag
       state: 'on'
-      
+
   action:
     service: input_boolean.turn_off
     entity_id: input_boolean.gary_far_away_flag
-

--- a/sample-automations-scripts/au_icloud.yaml
+++ b/sample-automations-scripts/au_icloud.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   IPHONE/ICLOUD SELECTION AUTOMATIONS
@@ -24,7 +26,7 @@
     - service: device_tracker.icloud3_update
       data_template:
         account_name: gary_icloud
-        command: "{{ states.input_select.icloud3_commands.state }}"        
+        command: "{{ states.input_select.icloud3_commands.state }}"
 
 - alias: iCloud Debug Command
   id: icloud3_debug_command

--- a/sample-automations-scripts/cov_garage_door.yaml
+++ b/sample-automations-scripts/cov_garage_door.yaml
@@ -1,10 +1,13 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:comments-indentation
+
 #########################################################
 #
 #   GARAGE DOOR ZWAVE SWITCH VIA SMARTTHINGS
 #
 #########################################################
 
-#---- Garage Door Z-Wave switch ----------------------------
+# --- Garage Door Z-Wave switch ----------------------------
 
 - platform: template
   covers:
@@ -39,5 +42,3 @@
 #        {% else %}
 #          mdi:arrow-expand-up
 #        {% endif %}
-          
-          

--- a/sample-automations-scripts/customize.yaml
+++ b/sample-automations-scripts/customize.yaml
@@ -1,3 +1,6 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:line-length
+
 #########################################################
 #
 #   LOCATION AND DEVICE TRACKER ENTITIES
@@ -8,7 +11,7 @@ device_tracker.gary:
   entity_picture: /local/gary.png
 device_tracker.gary_iphone:
   friendly_name: Gary
-   
+
 #########################################################
 #
 #   GARAGE DOOR ENTITIES
@@ -21,12 +24,12 @@ sensor.garage_door_battery:
   friendly_name: Garage Door Battery Level
   icon: mdi:battery
   unit_of_measurement: '%'
-  
+
 sensor.garage_door:
   friendly_name: Garage Door
   icon: mdi:garage
   homebridge_visible: false
-  
+
 switch.garage_door:
   friendly_name: Garage Door Switch
   emulated_hue_hidden: false
@@ -35,9 +38,9 @@ cover.garage_door:
   friendly_name: Garage Door
   emulated_hue_hidden: false
   templates:
-   icon_color: "if (entities['switch.garage_door'].state === 'on') return 'red'; else if (entities['sensor.garage_door'].state === 'Open') return 'red'; else return 'dodgerblue';"
-   state:      "if (entities['sensor.garage_door'].state === 'Open') return 'Lower'; else return 'Raise';"
-   icon:       "if (entities['switch.garage_door'].state === 'on') return 'mdi:cached'; else if (entities['sensor.garage_door'].state === 'Open') return 'mdi:arrow-expand-down'; else return 'mdi:arrow-expand-up';"
+    icon_color: "if (entities['switch.garage_door'].state === 'on') return 'red'; else if (entities['sensor.garage_door'].state === 'Open') return 'red'; else return 'dodgerblue';"
+    state: "if (entities['sensor.garage_door'].state === 'Open') return 'Lower'; else return 'Raise';"
+    icon: "if (entities['switch.garage_door'].state === 'on') return 'mdi:cached'; else if (entities['sensor.garage_door'].state === 'Open') return 'mdi:arrow-expand-down'; else return 'mdi:arrow-expand-up';"
 
 #########################################################
 #
@@ -48,16 +51,14 @@ input_boolean.gary_driving_flag:
   friendly_name: Gary Driving Flag
   templates:
     icon_color: "if (state === 'on') return 'red'; else return 'dodgerblue';"
-    icon:       "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
+    icon: "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
 
 input_boolean.gary_far_away_flag:
   friendly_name: Gary Far Away Flag
   templates:
     icon_color: "if (state === 'on') return 'red'; else return 'dodgerblue';"
-    icon:       "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
+    icon: "if (state === 'on') return 'mdi:checkbox-marked-outline'; else return 'mdi:close-box-outline';"
 
 sensor.someone_home_flag_formatted:
   friendly_name: Someone Home Flag
   icon: mdi:home
-  
- 

--- a/sample-automations-scripts/device_tracker.yaml
+++ b/sample-automations-scripts/device_tracker.yaml
@@ -1,10 +1,13 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:comments-indentation
+
 #########################################################
 #
 #   DEVICE_TRACKERS
 #
 #########################################################
 
-#----  iCloud iPhone Location Services ------------------------
+# ---  iCloud iPhone Location Services ------------------------
 device_tracker:
   - platform: icloud3
     username: gary-fmf-acct@email.com
@@ -13,16 +16,14 @@ device_tracker:
       - gary_iphone > gary-icloud-acct@email.com, gary.jpg
       - lillian_iphone > lillian-icloud-acct@email.com, lillian.jpg
 
+  # ---- Second instance of iCloud3 -----
+  # - platform: icloud3
+  #   username: sydney-fmf-acct@email.com
+  #   password: sydney-fmf-password
+  #   track_devices:
+  #     - sydney > sydney-icloud-acct@email.com, sydney.png
 
-#----- Second instance of iCloud3 ----- 
-#  - platform: icloud3
-#    username: sydney-fmf-acct@email.com
-#    password: sydney-fmf-password
-#    track_devices:
-#      - sydney > sydney-icloud-acct@email.com, sydney.png
-  
-  
-#----- Other Configuration Variables -----
+# ---- Other Configuration Variables -----
 #    group: family
 
 #    inzone_interval: '2 hrs'
@@ -45,4 +46,3 @@ device_tracker:
 #    exclude_sensors: cnt,lupdt,zon3,lzon3,alt
 
 #    log_level: debug
-  

--- a/sample-automations-scripts/ib_home_away_flags.yaml
+++ b/sample-automations-scripts/ib_home_away_flags.yaml
@@ -1,15 +1,15 @@
+# yamllint disable rule:document-start
 
-#----- Gary Home Flags -------------------
+# ----- Gary Home Flags -------------------
 #   This is set in Automation_old>home_away>Set Gary Driving Flag (Turn On)
 #   and reset in Automation_old>home_away>Set Gary Arrive Home
 gary_driving_flag:
   name: Gary Driving Flag
-  
+
 gary_far_away_flag:
   name: Gary Far Away Flag
-  
+
 gary_iphone_zone_change:
   name: Gary Zone Change
   icon: mdi:checkbox-marked-outline
-  initial: off
- 
+  initial: 'off'

--- a/sample-automations-scripts/is_icloud.yaml
+++ b/sample-automations-scripts/is_icloud.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   IPHONE/ICLOUD ATTRIBUTE INPUT SELECTS
@@ -13,7 +15,7 @@ icloud3_commands:
     - Pause garyiphone
     - Resume garyiphone
   icon: mdi:apple-keyboard-command
-  
+
 icloud3_set_interval:
   name: iCloud Set Interval
   options:
@@ -40,4 +42,3 @@ icloud3_debug_commands:
     - debug gps
     - debug old
   icon: mdi:android-debug-bridge
- 

--- a/sample-automations-scripts/sc_garage_door.yaml
+++ b/sample-automations-scripts/sc_garage_door.yaml
@@ -1,3 +1,6 @@
+# yamllint disable rule:document-start
+# yamllint disable rule:line-length
+
 #########################################################
 #
 #   SCRIPTS
@@ -7,36 +10,36 @@
 #
 #########################################################
 
-#--------------------------------------------------------------- 
+# --------------------------------------------------------------
 #   If garage door is closed and Gary's driving flag is true
 #   open the Garage Door, turn off Gary's driving flag and notify Gary
 #   Called from automation_old/garage_door.yaml
-#--------------------------------------------------------------- 
+# --------------------------------------------------------------
 open_garage_door:
   alias: 'Open Garage Door'
   sequence:
-    
-    #- condition: state
-    #  entity_id: input_boolean.ha_started_flag
-    #  state: 'on'
-      
+
+    # - condition: state
+    #   entity_id: input_boolean.ha_started_flag
+    #   state: 'on'
+
     - condition: state
       entity_id: sensor.garage_door
       state: 'Closed'
-      
-    - condition: template 
+
+    - condition: template
       value_template: '{{states.sensor.gary_iphone_zone_distance.state  | float <= 0.30}}'
-   
+
     - condition: state
       entity_id: input_boolean.gary_driving_flag
       state: 'on'
- 
+
     - condition: state
       entity_id: input_boolean.gary_far_away_flag
       state: 'off'
-      
+
     - service: script.show_garage_door_status
-  
+
     - service: switch.turn_on
       entity_id: switch.garage_door
 

--- a/sample-automations-scripts/sc_home_away_gary.yaml
+++ b/sample-automations-scripts/sc_home_away_gary.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 ##############################################################
 #
 #   HOME/AWAY SCRIPTS - Gary
@@ -10,71 +12,71 @@ gary_status:
     - service: script.notify_gary_iphone
       data_template:
         title: 'Gary Status'
-        message: 'Zone={{states.sensor.gary_iphone_zone.state}}, 
-                  Zone1={{states.sensor.gary_iphone_zone_name1.state}}, 
-                  Zone2={{states.sensor.gary_iphone_zone_name2.state}}, 
+        message: 'Zone={{states.sensor.gary_iphone_zone.state}},
+                  Zone1={{states.sensor.gary_iphone_zone_name1.state}},
+                  Zone2={{states.sensor.gary_iphone_zone_name2.state}},
                   Distance={{states.sensor.gary_iphone_zone_distance.state}},
                   DriveFlag={{states.input_boolean.gary_driving_flag.state}},
                   FarFlag={{states.input_boolean.gary_far_away_flag.state}}'
-  
-#-------------------------------------------------------------
+
+# ------------------------------------------------------------
 #   Arrive Home
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 gary_arrives_home:
   alias: 'Gary Arrives Home'
   sequence:
-    #Open garage door if driving flag is on
-    - service: script.open_garage_door 
-    
-    #Turn off 'Away' flags
+    # Open garage door if driving flag is on
+    - service: script.open_garage_door
+
+    # Turn off 'Away' flags
     - service: input_boolean.turn_off
       entity_id: input_boolean.gary_driving_flag
     - service: input_boolean.turn_off
       entity_id: input_boolean.gary_far_away_flag
-    
-    #Change Gary badge to home
+
+    # Change Gary badge to home
     - service: mqtt.publish
       data_template:
-        topic: 'location/gary' 
+        topic: 'location/gary'
         payload: 'home'
-        
-    #If already home, do not issue 'zone home' command
+
+    # If already home, do not issue 'zone home' command
     - condition: template
       value_template: '{{states.device_tracker.gary_iphone.state != "home"}}'
-    
-    #Issue 'zone home' command
+
+    # Issue 'zone home' command
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone home'
+        device_name: gary_iphone
+        command: 'zone home'
 
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 #   Leave Home
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 gary_leaves_home:
   alias: 'Gary Leaves Home'
   sequence:
-    #Change Gary badge to Away
+    # Change Gary badge to Away
     - service: mqtt.publish
       data_template:
-        topic: 'location/gary' 
+        topic: 'location/gary'
         payload: 'not_home'
-       
-#-------------------------------------------------------------
+
+# ------------------------------------------------------------
 #    Leave Other Zone
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 gary_leaves_zone:
   alias: 'Gary Leaves Zone'
   sequence:
-    #Change Gary badge to Away
+    # Change Gary badge to Away
     - service: mqtt.publish
       data_template:
-        topic: 'location/gary' 
+        topic: 'location/gary'
         payload: 'not_home'
- 
-#-------------------------------------------------------------
+
+# ------------------------------------------------------------
 #   Send Message to Gary - Central Notify Command
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 notify_gary_iphone:
   alias: 'Send Message to Gary'
   sequence:
@@ -82,7 +84,7 @@ notify_gary_iphone:
       data_template:
         title: "{{ title }} (IOS)"
         message: "{{ message }}"
-          
+
 #    - service: notify.mobile_app_gary_iphone
 #      data_template:
 #        title: "{{ title }} (mobile_app)"

--- a/sample-automations-scripts/sc_icloud3.yaml
+++ b/sample-automations-scripts/sc_icloud3.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   DEVICE_TRACKER/ICLOUD3.PY CUSTOM COMPONENT SUPPORT SCRIPTS
@@ -5,23 +7,23 @@
 #########################################################
 
 
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 #   GENERAL ICLOUD COMMANDS
-#-------------------------------------------------------------
+# ------------------------------------------------------------
 icloud3_command_restart:
   alias: 'Restart iCloud (Command)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: restart
-       
+
 icloud3_command_resume_polling:
   alias: 'Resume Polling'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: resume
-        
+
 icloud3_command_pause_polling:
   alias: 'Pause Polling'
   sequence:
@@ -35,35 +37,35 @@ icloud3_command_toggle_waze:
     - service: device_tracker.icloud3_update
       data:
         command: waze toggle
-        
+
 icloud3_command_reset_waze_range:
   alias: 'Reset Waze Range'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: waze reset_range
-        
+
 icloud3_update_location:
   alias: 'Update Location (all)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: location
-#------------------------------------------------------------          
+# -----------------------------------------------------------
 icloud3_set_interval_1_min:
   alias: 'Interval - 1 min'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: 1
-        
+
 icloud3_set_interval_5_min:
   alias: 'Interval - 5 min'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: 5
-               
+
 icloud3_set_interval_15_min:
   alias: 'Interval - 15 min'
   sequence:
@@ -77,48 +79,48 @@ icloud3_set_interval_30_min:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: '30 min'
- 
+
 icloud3_set_interval_1_hrs:
   alias: 'Interval -  1 hrs'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: '1 hr'
-                
+
 icloud3_set_interval_5_hrs:
   alias: 'Interval -   5 hrs'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         interval: '5 hr'
-  
 
-#--------------------------------------------------------------
+
+# -------------------------------------------------------------
 #   Set iCloud commands for Gary
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 icloud3_command_resume_polling_gary:
   alias: 'Resume (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: gary_iphone
-        command:     resume
-        
+        command: resume
+
 icloud3_command_pause_polling_gary:
   alias: 'Pause (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: gary_iphone
-        command:     pause
-              
+        command: pause
+
 icloud3_set_interval_10_min_gary:
   alias: 'Interval - 10 min (Gary)'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         device_name: gary_iphone
-        interval:   '10 min'
+        interval: '10 min'
 
 icloud3_set_interval_2_min_gary:
   alias: 'Interval -  1 min (Gary)'
@@ -126,15 +128,15 @@ icloud3_set_interval_2_min_gary:
     - service: device_tracker.icloud3_set_interval
       data:
         device_name: gary_iphone
-        interval:   '1 min'
-        
+        interval: '1 min'
+
 icloud3_lost_iphone_gary:
   alias: 'Find Lost Phone Alert (Gary)'
   sequence:
     - service: device_tracker.icloud3_lost_iphone
       data:
         device_name: gary_iphone
-       
+
     - service: script.notify_gary_iphone
       data_template:
         title: 'Lost iPhone Notification'
@@ -146,33 +148,34 @@ icloud3_update_location_gary:
     - service: device_tracker.icloud3_update
       data:
         device_name: gary_iphone
-        command:     location
-#--------------------------------------------------------------
+        command: location
+
+# -------------------------------------------------------------
 #   Set iCloud polling interval for Lillian (lillian_icloud account)
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 icloud3_command_resume_polling_lillian:
   alias: 'Resume (Lillian)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: lillian_icloud
-        command:     resume
-        
+        command: resume
+
 icloud3_command_pause_polling_lillian:
   alias: 'Pause (Lillian)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         device_name: lillian_icloud
-        command:     pause
- 
+        command: pause
+
 icloud3_set_interval_10_min_lillian:
   alias: 'Interval - 10 min (Lillian)'
   sequence:
     - service: device_tracker.icloud3_set_interval
       data:
         device_name: lillian_iphone
-        interval:    '10 min'
+        interval: '10 min'
 
 icloud3_set_interval_1_min_lillian:
   alias: 'Interval - 1 min (Lillian)'
@@ -181,7 +184,7 @@ icloud3_set_interval_1_min_lillian:
       data:
         device_name: lillian_iphone
         interval: 1
-        
+
 icloud3_lost_iphone_lillian:
   alias: 'Find Lost Phone Alert (Lillian)'
   sequence:
@@ -195,13 +198,13 @@ icloud3_lost_iwatch_lillian:
     - service: device_tracker.icloud3_lost_iphone
       data:
         device_name: lillian_iwatch
-        
+
 icloud3_lost_iphone_invalid:
   alias: 'Find Lost Phone Alert (Invalid)'
   sequence:
     - service: device_tracker.icloud3_lost_iphone
       data:
-        device_name: invalid_iphone 
+        device_name: invalid_iphone
 
 icloud3_update_location_lillian:
   alias: 'Update Location (Lillian)'
@@ -209,51 +212,52 @@ icloud3_update_location_lillian:
     - service: device_tracker.icloud3_update
       data:
         device_name: lillian_iphone
-        command:     location
-#--------------------------------------------------------------
+        command: location
+
+# -------------------------------------------------------------
 #   ZONE COMMANDS
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 
 icloud3_command_gary_iphone_zone_home:
   alias: 'Set Zone Home (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone home'
+        device_name: gary_iphone
+        command: 'zone home'
 
 icloud3_command_gary_iphone_zone_quail:
   alias: 'Set Zone Quail (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone Quail'
-        
+        device_name: gary_iphone
+        command: 'zone Quail'
+
 icloud3_command_gary_iphone_zone_not_home:
   alias: 'Set Zone Away (Gary)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  gary_iphone
-        command:     'zone not_home'
-        
+        device_name: gary_iphone
+        command: 'zone not_home'
+
 icloud3_command_lillian_iphone_zone_home:
   alias: 'Set Zone Home (Lillian/gary_icloud)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  lillian_iphone
-        command:     'zone home'
-        
+        device_name: lillian_iphone
+        command: 'zone home'
+
 icloud3_command_lillian_iphone_zone_not_home:
   alias: Set Zone Away (Lillian/gary_icloud)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
-        device_name:  lillian_iphone
-        command:     'zone not_home'
-        
+        device_name: lillian_iphone
+        command: 'zone not_home'
+
 icloud3_gary_iphone_see_away:
   alias: 'Set Away via device_tracker.see svc call (Gary)'
   sequence:
@@ -261,26 +265,25 @@ icloud3_gary_iphone_see_away:
       data:
         dev_id: gary_iphone
         location_name: 'not_home'
-        
- 
 
-#--------------------------------------------------------------
+
+# -------------------------------------------------------------
 #   INFORMATION COMMANDS
-#--------------------------------------------------------------
+# -------------------------------------------------------------
 icloud3_command_loglevel_debug:
   alias: 'LogLevel-Debug Info to HA Log (Toggle)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: log_level debug
-        
+
 icloud3_command_loglevel_intervalcalc:
   alias: 'LogLevel-Interval Calc (Toggle)'
   sequence:
     - service: device_tracker.icloud3_update
       data:
         command: log_level _intervalcalc
-        
+
 icloud3_command_loglevel_eventlog:
   alias: 'LogLevel-Event Log (Toggle)'
   sequence:
@@ -294,7 +297,7 @@ icloud3_command_loglevel_debug_eventlog:
     - service: device_tracker.icloud3_update
       data:
         command: log_level debug, eventlog
- 
+
 icloud3_command_loglevel_intervalcalc_eventlog:
   alias: 'LogLevel-Interval Calc & EventLog (Toggle)'
   sequence:
@@ -308,5 +311,3 @@ icloud3_command_loglevel_info:
     - service: device_tracker.icloud3_update
       data:
         command: log_level info
-
-

--- a/sample-automations-scripts/sn_badges.yaml
+++ b/sample-automations-scripts/sn_badges.yaml
@@ -1,26 +1,27 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   BADGE TEMPLATE SENSORS
 #
 #########################################################
-#--- Gary/Lillian location badge --------------------
+# -- Gary/Lillian location badge --------------------
 - platform: template
   sensors:
-    gary_iphone_badge_x:  
+    gary_iphone_badge_x:
       friendly_name: Gary
       value_template: '{{states.sensor.garyc_badge.state}}'
       entity_picture_template: /local/gary.png
-   
-#--- Garage Door Open/Closed --------------------
+
+# -- Garage Door Open/Closed --------------------
 - platform: template
   sensors:
     garage_door_badge:
       value_template: >-
-        {{states.sensor.garage_door.state}} 
+        {{states.sensor.garage_door.state}}
       entity_picture_template: >-
         {% if states.sensor.garage_door.state == "Closed" %}
           /local/garage-door-closed.png
         {% else %}
-          /local/garage-door-open.png 
+          /local/garage-door-open.png
         {% endif %}
-              

--- a/sample-automations-scripts/sn_garage_door.yaml
+++ b/sample-automations-scripts/sn_garage_door.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   GARAGE DOOR MQTT SENSOR
@@ -14,4 +16,3 @@
   name: "garage_door_battery"
   state_topic: "smartthings/Garage Door/battery/state"
   device_class: battery
-  

--- a/sample-automations-scripts/sw_garage_door.yaml
+++ b/sample-automations-scripts/sw_garage_door.yaml
@@ -1,10 +1,12 @@
+# yamllint disable rule:document-start
+
 #########################################################
 #
 #   GARAGE DOOR ZWAVE SWITCH VIA SMARTTHINGS
 #
 #########################################################
 
-#---- Garage Door Z-Wave switch ----------------------------
+# ---- Garage Door Z-Wave switch ---------------------------
 - platform: mqtt
   name: "garage_door"
   state_topic: "smartthings/Garage Door/switch/state"
@@ -12,5 +14,3 @@
   payload_on: "on"
   payload_off: "off"
   retain: false
-         
-          

--- a/sample-lovelace-cards/ui-lovelace-gary-2-zones-4x3.yaml
+++ b/sample-lovelace-cards/ui-lovelace-gary-2-zones-4x3.yaml
@@ -1,131 +1,131 @@
+# yamllint disable rule:document-start
 
-#----------------------------------------------- Gary (Home Zone)
-  - title: Location (Gary)
-    icon: mdi:cellphone-iphone
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: glance
-            title: Location Info - Gary
-            column_width: 25%
-            entities:
-              - entity: device_tracker.gary_iphone
-                name: Gary
-              - entity: sensor.gary_iphone_interval
-                name: Interval
-                icon: mdi:clock-start
-              - entity: sensor.gary_iphone_travel_time
-                name: TravTime
-                icon: mdi:clock-outline
-              - entity: sensor.gary_iphone_zone_distance
-                name: HomeDist
-                icon: mdi:map-marker-distance 
-         
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.gary_iphone_waze_distance
-                name: WazeDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.gary_iphone_calc_distance
-                name: CalcDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.gary_iphone_dir_of_travel
-                name: Direction
-                icon: mdi:compass-outline
-              - entity: input_boolean.gary_driving_flag
-                name: Driving
-                tap_action:  
-                  action: toggle
+# ---------------------------------------------- Gary (Home Zone)
+- title: Location (Gary)
+  icon: mdi:cellphone-iphone
+  cards:
+    - type: vertical-stack
+      cards:
+        - type: glance
+          title: Location Info - Gary
+          column_width: 25%
+          entities:
+            - entity: device_tracker.gary_iphone
+              name: Gary
+            - entity: sensor.gary_iphone_interval
+              name: Interval
+              icon: mdi:clock-start
+            - entity: sensor.gary_iphone_travel_time
+              name: TravTime
+              icon: mdi:clock-outline
+            - entity: sensor.gary_iphone_zone_distance
+              name: HomeDist
+              icon: mdi:map-marker-distance
 
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.gary_iphone_last_located
-                name: Located
-                icon: mdi:history
-              - entity: sensor.gary_iphone_last_update
-                name: LastUpdt
-                icon: mdi:history
-              - entity: sensor.gary_iphone_next_update
-                name: NextUpdt
-                icon: mdi:update
-              - entity: sensor.gary_iphone_poll_count
-                name: PollCount
-                icon: mdi:counter
-                tap_action: 
-                  action: call-service
-                  service: script.icloud3_command_event_log_gary
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.gary_iphone_waze_distance
+              name: WazeDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.gary_iphone_calc_distance
+              name: CalcDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.gary_iphone_dir_of_travel
+              name: Direction
+              icon: mdi:compass-outline
+            - entity: input_boolean.gary_driving_flag
+              name: Driving
+              tap_action:
+                action: toggle
 
-          - type: entities
-            entities:
-              - entity: sensor.gary_iphone_info
-                name: Info
-                icon: mdi:information-outline 
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.gary_iphone_last_located
+              name: Located
+              icon: mdi:history
+            - entity: sensor.gary_iphone_last_update
+              name: LastUpdt
+              icon: mdi:history
+            - entity: sensor.gary_iphone_next_update
+              name: NextUpdt
+              icon: mdi:update
+            - entity: sensor.gary_iphone_poll_count
+              name: PollCount
+              icon: mdi:counter
+              tap_action:
+                action: call-service
+                service: script.icloud3_command_event_log_gary
 
-#----------------------------------------------- Gary (Warehouse Zone)
-      - type: vertical-stack
-        cards:
-          - type: glance
-            title: Location Info - Gary (Warehouse)
-            column_width: 25%
-            entities:
-              - entity: device_tracker.gary_iphone
-                name: Gary
-              - entity: sensor.whse_gary_iphone_interval
-                name: Interval
-                icon: mdi:clock-start
-              - entity: sensor.whse_gary_iphone_travel_time
-                name: TravTime
-                icon: mdi:clock-outline
-              - entity: sensor.whse_gary_iphone_zone_distance
-                name: WhseDist
-                icon: mdi:map-marker-distance 
-         
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.whse_gary_iphone_waze_distance
-                name: WazeDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.whse_gary_iphone_calc_distance
-                name: CalcDist
-                icon: mdi:map-marker-distance
-              - entity: sensor.whse_gary_iphone_dir_of_travel
-                name: Direction
-                icon: mdi:compass-outline
-              - entity: input_boolean.gary_driving_flag
-                name: Driving
-                tap_action:  
-                  action: toggle
+        - type: entities
+          entities:
+            - entity: sensor.gary_iphone_info
+              name: Info
+              icon: mdi:information-outline
 
-          - type: glance
-            column_width: 25%
-            entities:
-              - entity: sensor.whse_gary_iphone_last_located
-                name: Located
-                icon: mdi:history
-              - entity: sensor.whse_gary_iphone_last_update
-                name: LastUpdt
-                icon: mdi:history
-              - entity: sensor.whse_gary_iphone_next_update
-                name: NextUpdt
-                icon: mdi:update
-              - entity: sensor.whse_gary_iphone_poll_count
-                name: PollCount
-                icon: mdi:counter
-                tap_action: 
-                  action: call-service
-                  service: script.icloud3_command_event_log_gary
- 
-          - type: entities
-            entities:
-              - entity: sensor.whse_gary_iphone_info
-                name: Info
-                icon: mdi:information-outline 
+    # ------------------------------------- Gary (Warehouse Zone)
+    - type: vertical-stack
+      cards:
+        - type: glance
+          title: Location Info - Gary (Warehouse)
+          column_width: 25%
+          entities:
+            - entity: device_tracker.gary_iphone
+              name: Gary
+            - entity: sensor.whse_gary_iphone_interval
+              name: Interval
+              icon: mdi:clock-start
+            - entity: sensor.whse_gary_iphone_travel_time
+              name: TravTime
+              icon: mdi:clock-outline
+            - entity: sensor.whse_gary_iphone_zone_distance
+              name: WhseDist
+              icon: mdi:map-marker-distance
 
-          - type: entities
-            entities:
-              - script.icloud3_update_location_gary
-              - script.homeassistant_restart
-              
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.whse_gary_iphone_waze_distance
+              name: WazeDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.whse_gary_iphone_calc_distance
+              name: CalcDist
+              icon: mdi:map-marker-distance
+            - entity: sensor.whse_gary_iphone_dir_of_travel
+              name: Direction
+              icon: mdi:compass-outline
+            - entity: input_boolean.gary_driving_flag
+              name: Driving
+              tap_action:
+                action: toggle
+
+        - type: glance
+          column_width: 25%
+          entities:
+            - entity: sensor.whse_gary_iphone_last_located
+              name: Located
+              icon: mdi:history
+            - entity: sensor.whse_gary_iphone_last_update
+              name: LastUpdt
+              icon: mdi:history
+            - entity: sensor.whse_gary_iphone_next_update
+              name: NextUpdt
+              icon: mdi:update
+            - entity: sensor.whse_gary_iphone_poll_count
+              name: PollCount
+              icon: mdi:counter
+              tap_action:
+                action: call-service
+                service: script.icloud3_command_event_log_gary
+
+        - type: entities
+          entities:
+            - entity: sensor.whse_gary_iphone_info
+              name: Info
+              icon: mdi:information-outline
+
+        - type: entities
+          entities:
+            - script.icloud3_update_location_gary
+            - script.homeassistant_restart

--- a/sample-lovelace-cards/ui-lovelace-home-whse_5x2.yaml
+++ b/sample-lovelace-cards/ui-lovelace-home-whse_5x2.yaml
@@ -1,4 +1,4 @@
-
+# yamllint disable rule:document-start
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
     type: js
@@ -24,11 +24,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: Home
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -47,20 +47,20 @@ views:
               - entity: sensor.gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
-              
+
           - type: horizontal-stack
             cards:
-            - type: entities
-              entities:
-                - entity: sensor.gary_iphone_info
-                  name: Info
-                  icon: mdi:information-outline 
+              - type: entities
+                entities:
+                  - entity: sensor.gary_iphone_info
+                    name: Info
+                    icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
-              
+
       - type: vertical-stack
         cards:
           - type: glance
@@ -77,11 +77,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.whse_gary_iphone_zone_distance
                 name: Whse
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.whse_gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -100,10 +100,9 @@ views:
               - entity: sensor.whse_gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
- 
+
           - type: entities
             entities:
               - entity: sensor.whse_gary_iphone_info
                 name: Info
-                icon: mdi:information-outline 
-
+                icon: mdi:information-outline

--- a/sample-lovelace-cards/ui-lovelace_all.yaml
+++ b/sample-lovelace-cards/ui-lovelace_all.yaml
@@ -1,15 +1,16 @@
+# yamllint disable rule:document-start
 
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
     type: js
-   
+
 title: Home
 views:
 
-#=============================================================
+  # ==========================================================
   - title: Main
     icon: mdi:star-outline
-    cards:        
+    cards:
       - type: vertical-stack
         cards:
           - type: glance
@@ -22,7 +23,7 @@ views:
                 name: Lillian
               - entity: sensor.garage_door_badge
                 name: Garage
-               
+
       - type: map
         entities:
           - device_tracker.gary_iphone
@@ -30,8 +31,8 @@ views:
           - zone.home
           - zone.quail
           - zone.whse
-          
-#=============================================================
+
+  # ==========================================================
   - title: Location (Gary)
     icon: mdi:cellphone-iphone
     cards:
@@ -51,11 +52,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -74,21 +75,21 @@ views:
               - entity: sensor.gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
-              
+
           - type: horizontal-stack
             cards:
-            - type: entities
-              entities:
-                - entity: sensor.gary_iphone_info
-                  name: Info
-                  icon: mdi:information-outline 
+              - type: entities
+                entities:
+                  - entity: sensor.gary_iphone_info
+                    name: Info
+                    icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
 
-#-------------------------------------------------------------            
+      # ------------------------------------------------------
       - type: vertical-stack
         cards:
           - type: glance
@@ -105,11 +106,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.lillian_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.lillian_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -132,19 +133,19 @@ views:
             entities:
               - entity: sensor.lillian_iphone_info
                 name: Info
-                icon: mdi:information-outline 
+                icon: mdi:information-outline
 
-#=============================================================
+  # ==========================================================
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log
 
-#============================================================= 
+  # ==========================================================
   - title: iCloud Commands
     icon: mdi:cloud-upload-outline
-    cards: 
+    cards:
       - type: entities
         title: iCloud3 Device Tracker Commands
         show_header_toggle: false
@@ -164,11 +165,11 @@ views:
           - script.icloud3_command_reset_waze_range
           - script.icloud3_lost_iphone_invalid
           - script.icloud3_update_location
-          
+
       - type: entities
         title: iCloud3 Commands - Gary
         show_header_toggle: false
-        entities:   
+        entities:
           - script.icloud3_command_resume_polling_gary
           - script.icloud3_command_pause_polling_gary
           - script.icloud3_set_interval_2_min_gary
@@ -178,24 +179,21 @@ views:
           - script.icloud3_command_gary_iphone_zone_home
           - script.icloud3_update_location_gary
           - script.icloud3_lost_iphone_gary
-          
+
       - type: entities
         title: iCloud3 Service Calls
         show_header_toggle: false
-        entities:    
+        entities:
           - script.icloud3_lost_iphone_lillian
           - script.icloud3_lost_iwatch_lillian
           - script.icloud3_gary_iphone_see_away
           - script.icloud3_update_location_lillian
-          
+
       - type: entities
         entities:
-        - script.icloud3_command_loglevel_debug
-        - script.icloud3_command_loglevel_intervalcalc
-        - script.icloud3_command_loglevel_eventlog
-        - script.icloud3_command_loglevel_info
-        - script.icloud3_command_loglevel_debug_eventlog
-        - script.icloud3_command_loglevel_intervalcalc_eventlog
-        
-
-         
+          - script.icloud3_command_loglevel_debug
+          - script.icloud3_command_loglevel_intervalcalc
+          - script.icloud3_command_loglevel_eventlog
+          - script.icloud3_command_loglevel_info
+          - script.icloud3_command_loglevel_debug_eventlog
+          - script.icloud3_command_loglevel_intervalcalc_eventlog

--- a/sample-lovelace-cards/ui-lovelace_commands.yaml
+++ b/sample-lovelace-cards/ui-lovelace_commands.yaml
@@ -1,55 +1,56 @@
-  - title: iCloud Commands
-    icon: mdi:cloud-upload-outline
-    cards: 
-      - type: entities
-        title: iCloud3 Device Tracker Commands
-        show_header_toggle: false
-        entities:
-          - script.icloud3_command_resume_polling
-          - script.icloud3_command_pause_polling
-          - script.icloud3_command_restart
-          - type: divider
-          - script.icloud3_set_interval_1_min
-          - script.icloud3_set_interval_5_min
-          - script.icloud3_set_interval_15_min
-          - script.icloud3_set_interval_30_min
-          - script.icloud3_set_interval_1_hrs
-          - script.icloud3_set_interval_5_hrs
-          - type: divider
-          - script.icloud3_command_toggle_waze
-          - script.icloud3_command_reset_waze_range
-          - script.icloud3_lost_iphone_invalid
-          - script.icloud3_update_location
-          
-      - type: entities
-        title: iCloud3 Commands - Gary
-        show_header_toggle: false
-        entities:   
-          - script.icloud3_command_resume_polling_gary
-          - script.icloud3_command_pause_polling_gary
-          - script.icloud3_set_interval_2_min_gary
-          - script.icloud3_set_interval_10_min_gary
-          - script.icloud3_set_interval_1_min_lillian
-          - script.icloud3_set_interval_10_min_lillian
-          - script.icloud3_command_gary_iphone_zone_home
-          - script.icloud3_update_location_gary
-          - script.icloud3_lost_iphone_gary
-          
-      - type: entities
-        title: iCloud3 Service Calls, log_level Cmds
-        show_header_toggle: false
-        entities:    
-          - script.icloud3_lost_iphone_lillian
-          - script.icloud3_lost_iwatch_lillian
-          - script.icloud3_gary_iphone_see_away
-          - script.icloud3_update_location_lillian
-          
-      - type: entities
-        entities:
+# yamllint disable rule:document-start
+
+- title: iCloud Commands
+  icon: mdi:cloud-upload-outline
+  cards:
+    - type: entities
+      title: iCloud3 Device Tracker Commands
+      show_header_toggle: false
+      entities:
+        - script.icloud3_command_resume_polling
+        - script.icloud3_command_pause_polling
+        - script.icloud3_command_restart
+        - type: divider
+        - script.icloud3_set_interval_1_min
+        - script.icloud3_set_interval_5_min
+        - script.icloud3_set_interval_15_min
+        - script.icloud3_set_interval_30_min
+        - script.icloud3_set_interval_1_hrs
+        - script.icloud3_set_interval_5_hrs
+        - type: divider
+        - script.icloud3_command_toggle_waze
+        - script.icloud3_command_reset_waze_range
+        - script.icloud3_lost_iphone_invalid
+        - script.icloud3_update_location
+
+    - type: entities
+      title: iCloud3 Commands - Gary
+      show_header_toggle: false
+      entities:
+        - script.icloud3_command_resume_polling_gary
+        - script.icloud3_command_pause_polling_gary
+        - script.icloud3_set_interval_2_min_gary
+        - script.icloud3_set_interval_10_min_gary
+        - script.icloud3_set_interval_1_min_lillian
+        - script.icloud3_set_interval_10_min_lillian
+        - script.icloud3_command_gary_iphone_zone_home
+        - script.icloud3_update_location_gary
+        - script.icloud3_lost_iphone_gary
+
+    - type: entities
+      title: iCloud3 Service Calls, log_level Cmds
+      show_header_toggle: false
+      entities:
+        - script.icloud3_lost_iphone_lillian
+        - script.icloud3_lost_iwatch_lillian
+        - script.icloud3_gary_iphone_see_away
+        - script.icloud3_update_location_lillian
+
+    - type: entities
+      entities:
         - script.icloud3_command_loglevel_debug
         - script.icloud3_command_loglevel_intervalcalc
         - script.icloud3_command_loglevel_eventlog
         - script.icloud3_command_loglevel_info
         - script.icloud3_command_loglevel_debug_eventlog
         - script.icloud3_command_loglevel_intervalcalc_eventlog
-        

--- a/sample-lovelace-cards/ui-lovelace_event_log.yaml
+++ b/sample-lovelace-cards/ui-lovelace_event_log.yaml
@@ -1,14 +1,15 @@
+# yamllint disable rule:document-start
 
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
     type: js
-   
+
 title: Home
 views:
 
-#=============================================================
+  # ==========================================================
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log

--- a/sample-lovelace-cards/ui-lovelace_gc-5x2.yaml
+++ b/sample-lovelace-cards/ui-lovelace_gc-5x2.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 title: Home
 views:
   - title: Location (Gary)
@@ -19,11 +21,11 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: Home
-                icon: mdi:map-marker-distance 
+                icon: mdi:map-marker-distance
               - entity: sensor.gary_iphone_next_update
                 name: NextUpdt
                 icon: mdi:update
-         
+
           - type: glance
             column_width: 20%
             entities:
@@ -42,17 +44,16 @@ views:
               - entity: sensor.gary_iphone_last_update
                 name: LastUpdt
                 icon: mdi:history
-              
+
           - type: horizontal-stack
             cards:
-            - type: entities
-              entities:
-                - entity: sensor.gary_iphone_info
-                  name: Info
-                  icon: mdi:information-outline 
+              - type: entities
+                entities:
+                  - entity: sensor.gary_iphone_info
+                    name: Info
+                    icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
-

--- a/sample-lovelace-cards/ui-lovelace_gc_4x3.yaml
+++ b/sample-lovelace-cards/ui-lovelace_gc_4x3.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start
+
 title: Home
 views:
   - title: Location
@@ -19,8 +21,8 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
-         
+                icon: mdi:map-marker-distance
+
           - type: glance
             column_width: 25%
             entities:
@@ -35,7 +37,7 @@ views:
                 icon: mdi:compass-outline
               - entity: input_boolean.gary_driving_flag
                 name: Driving
-                tap_action:  
+                tap_action:
                   action: toggle
 
           - type: glance
@@ -53,21 +55,21 @@ views:
               - entity: sensor.gary_iphone_poll_count
                 name: PollCount
                 icon: mdi:counter
- 
+
           - type: entities
             entities:
               - entity: sensor.gary_iphone_info
                 name: Info
-                icon: mdi:information-outline 
+                icon: mdi:information-outline
 
           - type: entities
             entities:
               - script.icloud3_update_location_gary
               - script.homeassistant_restart
-              
-#----------------------------------------------------------------------
+
+  # -------------------------------------------------------------------
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log

--- a/sample-lovelace-cards/ui-lovelace_gc_lc_4x3.yaml
+++ b/sample-lovelace-cards/ui-lovelace_gc_lc_4x3.yaml
@@ -1,9 +1,9 @@
+# yamllint disable rule:document-start
 
 resources:
   - url: /local/custom_cards/icloud3-event-log-card.js?v=1.001
     type: js
 
-    
 title: Home
 views:
   - title: Location (Gary)
@@ -25,8 +25,8 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.gary_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
-         
+                icon: mdi:map-marker-distance
+
           - type: glance
             column_width: 25%
             entities:
@@ -41,7 +41,7 @@ views:
                 icon: mdi:compass-outline
               - entity: input_boolean.gary_driving_flag
                 name: Driving
-                tap_action:  
+                tap_action:
                   action: toggle
 
           - type: glance
@@ -59,13 +59,13 @@ views:
               - entity: sensor.gary_iphone_poll_count
                 name: PollCount
                 icon: mdi:counter
-  
+
           - type: entities
             entities:
               - entity: sensor.gary_iphone_info
                 name: Info
-                icon: mdi:information-outline 
-              
+                icon: mdi:information-outline
+
       - type: vertical-stack
         cards:
           - type: glance
@@ -82,8 +82,8 @@ views:
                 icon: mdi:clock-outline
               - entity: sensor.lillian_iphone_zone_distance
                 name: HomeDist
-                icon: mdi:map-marker-distance 
-         
+                icon: mdi:map-marker-distance
+
           - type: glance
             column_width: 25%
             entities:
@@ -98,7 +98,7 @@ views:
                 icon: mdi:compass-outline
               - entity: input_boolean.lillian_driving_flag
                 name: Driving
-                tap_action:  
+                tap_action:
                   action: toggle
 
           - type: glance
@@ -122,11 +122,10 @@ views:
               - entity: sensor.lillian_iphone_info
                 name: Info
                 icon: mdi:information-outline
-       
-#=============================================================
+
+  # ==========================================================
   - title: iCloud Event Log
-    icon: mdi:information-outline 
-    cards: 
+    icon: mdi:information-outline
+    cards:
       - type: custom:icloud3-event-log-card
         entity: sensor.icloud3_event_log
-


### PR DESCRIPTION
This cleans up all errors and warnings from yamllint. This includes trailing spaces, extra spaces after colons, missing leading spaces in comments, incorrect indentation and a few other items.
Directives have been added where required to ignore long lines and missing doc-start indicators (HA doesn't care about those).

This mostly touches only the 'sample' files, but does include some directives in services.yaml file.

It should make for a quieter output for those of us that run our configurations through some CI automation testing.