### PR TITLE
set correct `state_class` value

### DIFF
--- a/custom_components/icloud3/sensor.py
+++ b/custom_components/icloud3/sensor.py
@@ -1117,7 +1117,7 @@ class Sensor_Battery(SensorBase):
     @property
     def extra_state_attributes(self):
         extra_attrs = self._get_extra_attributes(self.sensor)
-        extra_attrs.update({'device_class': 'battery', 'state_class': 'battery'})
+        extra_attrs.update({'device_class': 'battery', 'state_class': 'measurement'})
 
         return extra_attrs
 


### PR DESCRIPTION
`state_class` can be one of `measurement`, `total` or `total_increasing`.

It was incorrectly set to `battery`.

See: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes

Choosing `measurement` is based on its description, and also this part of the description for the `total` variant:

> This (`total`) state class should not be used for sensors where the absolute value is interesting instead of the accumulated growth or decline, for example remaining battery capacity or CPU load; in such cases state class measurement should be used instead.

I ran into this as I was working on a hass library in Rust, which tries to codify all relevant types, including `device_class` (which does have a `battery` variant), and `state_class` (which does not).