### PR TITLE
Avoid conversion error at zone distance calculation

### DIFF
--- a/custom_components/icloud3/sensor.py
+++ b/custom_components/icloud3/sensor.py
@@ -508,7 +508,7 @@ class SensorBase(SensorEntity):
                 extra_attrs[_sensor_attr_name] = _sensor_value
 
                 if Gb.um_MI:
-                    zone_dist_m = self._get_sensor_value(ZONE_DISTANCE_M)
+                    zone_dist_m = float(self._get_sensor_value(ZONE_DISTANCE_M))
                     sensor_value_mi = zone_dist_m*Gb.um_km_mi_factor/1000
                     extra_attrs['distance_(miles)'] = set_precision(sensor_value_mi)
                     extra_attrs['distance_units_(attributes)'] = 'mi'


### PR DESCRIPTION
Hi @gcobb321, 
just observed those messages after a restart of HA 2024.1.6. Maybe you can review the change and adjust when needed. This error seems to only appear once when the integration is loaded.

```
2024-02-10 08:17:03.977 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up icloud3 platform for sensor
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 368, in _async_setup_platform
await asyncio.gather(*pending)
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
await asyncio.gather(*tasks)
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 752, in _async_add_entity
await entity.add_to_platform_finish()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1282, in add_to_platform_finish
self.async_write_ha_state()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 945, in async_write_ha_state
self._async_write_ha_state()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1066, in _async_write_ha_state
state, attr, capabilities, shadowed_attr = self.__async_calculate_state()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1006, in __async_calculate_state
attr.update(self.extra_state_attributes or {})
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/icloud3/sensor.py", line 1043, in extra_state_attributes
extra_attrs = self._get_extra_attributes(self.sensor)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/icloud3/sensor.py", line 512, in _get_extra_attributes
sensor_value_mi = zone_dist_m*Gb.um_km_mi_factor/1000
~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
TypeError: can't multiply sequence by non-int of type 'float'
```