### PR TITLE
fix(apple_acct): add socket timeout to outbound requests calls (refs #552)

### DIFF
--- a/custom_components/icloud3/apple_acct/icloud_requests_io.py
+++ b/custom_components/icloud3/apple_acct/icloud_requests_io.py
@@ -114,6 +114,13 @@ def request_get_post(url, **kwargs):
             occurred
     '''
 
+    # Prevent SyncWorker threads from blocking indefinitely on hung remote
+    # endpoints (notably the connectivity check in internet_error.py). Without
+    # a socket-level timeout, requests.get / requests.post can wait forever
+    # inside ssl.do_handshake() / sock.recv(), saturating HA's thread pool and
+    # leading to the symptoms reported in issue #552.
+    kwargs.setdefault("timeout", 30)
+
     try:
         error = 'InternetError-'
         code  = 104

--- a/custom_components/icloud3/apple_acct/icloud_session.py
+++ b/custom_components/icloud3/apple_acct/icloud_session.py
@@ -253,6 +253,12 @@ class iCloudSession(Session):
                 retry_cnt=retry_cnt)
 
     def _request(self, method, url, **kwargs, ):
+        # Prevent SyncWorker threads from blocking indefinitely on hung remote
+        # endpoints. Without a socket-level timeout, requests.Session can wait
+        # forever inside ssl.do_handshake() / sock.recv(), exhausting HA's
+        # thread pool. See issue #552 (segfault / connectivity hang reports).
+        kwargs.setdefault("timeout", 30)
+
         # callee.function and callee.lineno provice calling function and the line number
         callee = inspect.stack()[2]
         module = inspect.getmodule(callee[0])


### PR DESCRIPTION
## Summary

Both call sites that reach the `requests` library inside `apple_acct/` invoke it without a `timeout` kwarg:

- `icloud_session.py::iCloudSession._request` (used for all iCloud Session HTTP calls)
- `icloud_requests_io.py::request_get_post` (used by `internet_error.py::check_internet_connection`)

When the remote endpoint (e.g. an Apple host or DNS resolver) hangs during the SSL handshake or socket read, the underlying socket has no upper bound and the **SyncWorker thread that issued the call blocks forever**. Because Home Assistant shares a single bounded thread pool across all integrations, enough stuck workers can saturate it — at which point the event loop backs up and WebSocket / UI clients stall on "data loading" while the HTTP API itself still responds.

I hit this today in production: the HA iOS app hung on initial data loading, the HTTP `/api/` endpoint was responsive, and a thread dump showed **50+ SyncWorker threads parked inside `ssl.do_handshake()`** with stack traces ending in `internet_error.py → icloud_requests_io.py::request_get_post → requests.get(url, **kwargs)`. Issue #552 reports the same code path under a different failure mode (segfault under Python 3.13). The common root cause is "no socket timeout," so this PR closes the door on the whole class.

## Change

Add a single defensive line at the top of each function:

```python
kwargs.setdefault("timeout", 30)
```

`setdefault` is used so that any caller that already supplies its own `timeout` keeps full control; only callers that pass nothing inherit the safety net. 30s comfortably covers normal Apple round-trips while bounding the worst case.

## Files

- `custom_components/icloud3/apple_acct/icloud_session.py` — `_request`
- `custom_components/icloud3/apple_acct/icloud_requests_io.py` — `request_get_post`

## Verification

After applying the patch and restarting Home Assistant:

- Thread pool busy: 58/64 → 2/64
- Event loop lag: stalled → 36ms (cooling from boot)
- Watchdog "STALL DETECTED" warnings stopped firing
- iOS app reconnected normally
- Existing iCloud3 device tracking continued to work (no regressions observed)

## Related

- Refs #552 — same `check_internet_connection` code path; this change should prevent both the indefinite hang reported here and reduce the surface for the `pycares` / Python-3.13 segfault by ensuring stuck connection attempts unwind in a bounded time.