### PR TITLE
Fix KeyError when deleted_sensors missing during registry scan

### DIFF
--- a/custom_components/icloud3/utils/entity_reg_util.py
+++ b/custom_components/icloud3/utils/entity_reg_util.py
@@ -739,6 +739,8 @@ def combine_device_tracker_deleted_device_and_sensor_items():
     ic3_entity_items_dict = Gb.entity_reg_items_by_status
     if 'deleted_devices' not in  ic3_entity_items_dict:
         return
+    if 'deleted_sensors' not in ic3_entity_items_dict:
+        return
 
     for devicename, device_sensors in ic3_entity_items_dict['deleted_sensors'].copy().items():
         if devicename in ic3_entity_items_dict['deleted_devices']:


### PR DESCRIPTION
## Summary

Device sensor creation calls `get_disabled_sensors_list()` → `scan_entity_reg_for_icloud3_items()` → `combine_device_tracker_deleted_device_and_sensor_items()`.

When the entity registry has no deleted iCloud3 sensors, `entity_reg_items_by_status` may contain `deleted_devices` but not `deleted_sensors`. The existing code only early-returns when `deleted_devices` is missing, then unconditionally iterates `deleted_sensors`, raising `KeyError: 'deleted_sensors'` and preventing all per-device sensors (`sensor.<device>_travel_time_min`, `home_distance`, `dir_of_travel`, etc.) from being created.

Only integration-level sensors (`sensor.icloud3_event_log`, etc.) are created in that case. Device trackers may still work.

## Fix

Add a matching early-return when `deleted_sensors` is absent (same pattern as the existing `deleted_devices` guard). Behavior is unchanged when both keys exist.

```python
if 'deleted_devices' not in ic3_entity_items_dict:
    return
if 'deleted_sensors' not in ic3_entity_items_dict:
    return
```

## Environment where this was hit

- Home Assistant 2026.7.x
- iCloud3 v3.5.1
- Clean / fresh entity registry (no previously deleted iCloud3 sensors)
- Full HA restart

## Test plan

- [ ] Fresh HA + iCloud3 with tracked devices, no previously deleted sensors → startup creates `sensor.<device>_travel_time_min` etc.
- [ ] After deleting some sensors in UI, restart still succeeds and combine logic still runs when both `deleted_*` keys exist.
- [ ] Confirm no KeyError in logs on clean install startup.

## Related

Local workaround: apply the same two-line guard, then fully restart HA (config entry reload alone may keep the old module in memory).