### PR TITLE
Fix: pause_tracking()/resume_tracking() called without parentheses (5 sites)

### DIFF
--- a/custom_components/icloud3/apple_acct/icloud_data_handler.py
+++ b/custom_components/icloud3/apple_acct/icloud_data_handler.py
@@ -147,7 +147,7 @@ def request_icloud_data_update(Device):
 
             if Gb.internet_error:
                 for Device in Gb.Devices:
-                    Device.pause_tracking
+                    Device.pause_tracking()
                 return False
 
             # Retry in an error occurs

--- a/custom_components/icloud3/configure/screens/step_tools.py
+++ b/custom_components/icloud3/configure/screens/step_tools.py
@@ -326,14 +326,14 @@ class OptionsFlow_Tools_Steps:
                 self.create_device_tracker_sensor_enities_on_exit = True
 
                 if Device := Gb.Devices_by_devicename.get(devicename):
-                    Device.pause_tracking
+                    Device.pause_tracking()
 
                 sensors_cf.remove_device_tracker_and_sensor_entities(
                                                         self, devicename,
                                                         rebuild_ic3db_dashboards=False)
 
                 if Device:
-                    Device.resume_tracking
+                    Device.resume_tracking()
 
         except Exception as err:
             log_exception(err)

--- a/custom_components/icloud3/tracking/determine_interval.py
+++ b/custom_components/icloud3/tracking/determine_interval.py
@@ -749,10 +749,10 @@ def determine_interval_after_error(Device, counter=OLD_LOCATION_CNT):
         # has been cycled thru and started at the beginning again. Pause tracking
         # if cycled more than 8 times or 4 times and last location is over 2-days ago
         if Device.max_error_cycle_cnt > 8:
-            Device.pause_tracking
+            Device.pause_tracking()
         elif (Device.max_error_cycle_cnt > 4
                 and mins_since(Device.last_update_loc_secs) > 2880):
-            Device.pause_tracking
+            Device.pause_tracking()
         elif Device.max_error_cycle_cnt > 2:
             interval_secs = interval_secs * int(Device.max_error_cycle_cnt/2)
             if interval_secs > Gb.max_interval_secs:


### PR DESCRIPTION
### Summary

Five call sites reference `Device.pause_tracking` / `Device.resume_tracking` **without
parentheses**. Both are plain methods, so the expression evaluates the bound method and
discards it — no exception, no warning, no effect. The guards that rely on them never run.

### The sites

| File | Line | Current | Purpose that never happens |
|---|---|---|---|
| `tracking/determine_interval.py` | 752 | `Device.pause_tracking` | Pause after **8 failed retry cycles** |
| `tracking/determine_interval.py` | 755 | `Device.pause_tracking` | Pause after 4 cycles when last location > 2 days old |
| `apple_acct/icloud_data_handler.py` | 150 | `Device.pause_tracking` | Pause **all** devices on an internet error |
| `configure/screens/step_tools.py` | 329 | `Device.pause_tracking` | Pause before deleting an active device |
| `configure/screens/step_tools.py` | 336 | `Device.resume_tracking` | Matching resume |

Seven other calls to the same two methods are already written correctly, which is what
makes these five look accidental rather than stylistic:
`support/service_handler.py:353,362,558` · `configure/screens/step_tools.py:166` ·
`utils/entity_reg_util.py:87` · `apple_acct/internet_error.py:86,265`.

### Why this is functional, not cosmetic

```
pause_tracking()     -> self.tracking_status = TRACKING_PAUSED      (device.py:1416)
is_tracking_paused   -> tracking_status == TRACKING_PAUSED          (@property, device.py:1432)
```

`is_tracking_paused` gates the update loop in 13 places. The decisive one is
`apple_acct/icloud_data_handler.py:29`, in `no_icloud_update_needed_tracking()`, which sets
`icloud_no_update_reason = 'Paused'` — so a paused device issues **no iCloud request at
all**. Others: `icloud3_main.py:343` (`continue`), `icloud3_main.py:631` (`return`), plus
`icloud3_main.py:374,560,777,1369,1593`, `device.py:1894,2639`,
`service_handler.py:555`, `icloud_data_handler.py:612`.

### Observed behaviour

A device whose **Find My location sharing is turned off** is never locatable: iCloud
returns `device_status: Unknown`, `located: 0000-00-00 00:00:00`, and startup logs
`No Location Found`. iCloud3 then puts it on the error-retry ladder
`RETRY_INTERVAL_RANGE_1 = {0:.25, 4:.5, 8:1, 12:5, 16:15, 20:30, 24:60}` (minutes).

When the counter is exhausted, `reset_tracking_fields(interval_secs=5,
max_error_cnt_reached=True)` sends it **back to 5 seconds** and increments
`max_error_cycle_cnt`. Because lines 752 and 755 do nothing, the cycle never ends. The
`interval_secs * int(max_error_cycle_cnt/2)` multiplier widens it, capped at
`max_interval`, but the device never reaches `TRACKING_PAUSED`.

### How the sites were identified

AST analysis of the whole package rather than a text search (script attached,
`analyse_ic3.py <path>`), because a bare `obj.attr` statement is only a bug when `attr`
is **not** a property:

1. collect every method defined in a `ClassDef`, flagging `@property` ones;
2. collect every `ast.Expr` whose value is an `ast.Attribute`;
3. intersect.

**Result on `master`: 69 files, 624 methods (200 of them properties), 11 bare
attribute expressions.** They split cleanly in two:

- **6 are intentional** — `statzone_reset_timer` and `statzone_clear_timer` are decorated
  `@property` (`device.py:1381`, `1389`), so the bare expression does fire the getter
  that carries the side effect.
- **5 are the ones fixed here** — neither method is decorated.

After the patch, the analysis reports **no dead calls**, and the 6 intentional ones are
untouched.

> Note for anyone adding a linter: this class of bug is exactly `ruff` **B018**
> (*useless-expression*) / `pylint` *pointless-statement*. A plain run would also flag
> the 6 intentional `@property` expressions above, so they would need `# noqa: B018`
> (or conversion to explicit method calls) for the rule to be adoptable.

### Reproduction

1. On an Apple account, take a device with **Find My location sharing disabled**.
2. Set it to `tracking_mode: track` in iCloud3.
3. Watch `sensor.<device>_interval`: it walks the ladder, **restarts at the bottom**, and
   repeats indefinitely; `max_error_cycle_cnt` climbs past 8 without the state ever
   becoming `TRACKING_PAUSED`.

### Change

Adds the five missing `()`. No logic, no formatting, no line-count change; all three
files still parse.

### Note on the behaviour change

This makes pauses that were previously silent no-ops actually happen. Two of the five
sites are worth calling out before merging:

- `icloud_data_handler.py:150` now really pauses **every** device during an internet
  error. That is clearly the intent of the surrounding `if Gb.internet_error:` block,
  and `internet_error.py:265` already resumes them — but installations that have lived
  with the no-op may notice devices going `PAUSED` during an outage where they
  previously kept retrying.
- `determine_interval.py:752/755` now really stop tracking a device that has cycled the
  retry table 8 times (or 4 times with no location for 2 days). Intended, but it is a
  visible state change for anyone who has a permanently unlocatable device configured
  as `track`.

I'd rather flag this here than have it come back as a regression report.

### Environment

iCloud3 v3.7.5 (HACS) · Home Assistant 2026.9.1 · HA Yellow (CM4) · data source
`iCloud,MobApp` with no device bound to the Companion app (`mobile_app_device: "None"`),
so the iCloud path only.

